### PR TITLE
add huberts

### DIFF
--- a/nkululeko/feat_extract/feats_hubert.py
+++ b/nkululeko/feat_extract/feats_hubert.py
@@ -1,0 +1,120 @@
+# feats_hubert.py
+# HuBERT feature extractor for Nkululeko
+
+import os
+
+# import audiofile
+# import torchaudio
+import nkululeko.glob_conf as glob_conf
+import pandas as pd
+import torch
+import torchaudio
+from nkululeko.feat_extract.featureset import Featureset
+from nkululeko.util import Util as util
+from transformers import AutoProcessor, HubertModel, Wav2Vec2FeatureExtractor
+
+
+class Hubert(Featureset): 
+    """Class to extract HuBERT embedding)"""
+
+    def __init__(self, name, data_df, feat_type):
+        """Constructor. is_train is needed to distinguish from test/dev sets,
+        because they use the codebook from the training"""
+        super().__init__(name, data_df)
+        self.device = self.util.config_val("MODEL", "device", "cpu")
+        self.model_initialized = False
+        self.feat_type = feat_type
+
+    def init_model(self):
+        # load model
+        self.util.debug("loading Hubert model...")
+        
+        # extract ckpt based on feat_type
+        if self.feat_type == "hubert":
+            ckpt = "facebook/hubert-base-ls960"
+        elif self.feat_type == "hubert_ft":
+            ckpt = "facebook/hubert-large-ls960-ft"
+        elif self.feat_type == "hubert_large":
+            ckpt = "facebook/hubert-large-ll60k"
+        elif self.feat_type == "hubert_xlarge":
+            ckpt = "facebook/hubert-xlarge-ll60k"
+        elif self.feat_type == "hubert_xlarge_ft":
+            ckpt = "facebook/hubert-xlarge-ls960-ft"
+        else:
+            raise ValueError(f"feat_type {self.feat_type} not supported")
+
+        model_path = self.util.config_val("FEATS", "Hubert.model", ckpt)
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(model_path)
+        self.model = HubertModel.from_pretrained(model_path).to(self.device)
+        print(f"intialized Hubert model on {self.device}")
+        self.model.eval()
+        self.model_initialized = True
+
+    def extract(self):
+        """Extract the features or load them from disk if present."""
+        store = self.util.get_path("store")
+        storage = f"{store}{self.name}.pkl"
+        extract = self.util.config_val("FEATS", 
+            "needs_feature_extraction", False)
+        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        if extract or no_reuse or not os.path.isfile(storage):
+            if not self.model_initialized:
+                self.init_model()
+            self.util.debug(
+                "extracting Hubert embeddings, this might take a while..."
+            )
+            emb_series = pd.Series(index=self.data_df.index, dtype=object)
+            length = len(self.data_df.index)
+            for idx, (file, start, end) in enumerate(
+                    self.data_df.index.to_list()):
+                signal, sampling_rate = torchaudio.load(file)
+                if sampling_rate != 16000:
+                    resampler = torchaudio.transforms.Resample(
+                        sampling_rate, 16000)
+                    signal = resampler(signal)
+                    sampling_rate = 16000
+                emb = self.get_embeddings(signal, sampling_rate)
+                emb_series[idx] = emb
+                if idx % 10 == 0:
+                    self.util.debug(f"{self.feat_type}: {idx} of {length} done")
+            self.df = pd.DataFrame(
+                emb_series.values.tolist(), index=self.data_df.index)
+            self.df.to_pickle(storage)
+            try:
+                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+            except KeyError:
+                pass
+        else:
+            self.util.debug(f"reusing extracted {self.feat_type} embeddings")
+            self.df = pd.read_pickle(storage)
+            if self.df.isnull().values.any():
+                nanrows = self.df.columns[self.df.isna().any()].tolist()
+                print(nanrows)
+                self.util.error(
+                    f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
+                )
+
+    def get_embeddings(self, signal, sampling_rate):
+        r"""Extract embeddings from raw audio signal."""
+        with torch.no_grad():
+            # run through processor to normalize signal
+            # always returns a batch, so we just get the first entry
+            # then we put it on the device
+            y = self.processor(signal, sampling_rate=sampling_rate)
+            y = y["input_values"][0]
+            y = torch.from_numpy(y.reshape(1, -1)).to(self.device)
+            # print(y.shape)
+            # run through model
+            # first entry contains hidden state
+            y = self.model(y)[0]
+
+            # pool result and convert to numpy
+            y = torch.mean(y, dim=1)
+            y = y.detach().cpu().numpy()
+
+        return y.flatten()
+
+    def extract_sample(self, signal, sr):
+        self.init_model()
+        feats = self.get_embeddings(signal, sr)
+        return feats

--- a/nkululeko/feat_extract/feats_wav2vec2.py
+++ b/nkululeko/feat_extract/feats_wav2vec2.py
@@ -1,14 +1,14 @@
 # feats_wav2vec2.py
 
-from nkululeko.util import Util
-from nkululeko.feat_extract.featureset import Featureset
 import os
+
+import nkululeko.glob_conf as glob_conf
 import pandas as pd
 import torch
-import nkululeko.glob_conf as glob_conf
-import transformers
-from transformers.models.wav2vec2.modeling_wav2vec2 import Wav2Vec2Model
 import torchaudio
+from nkululeko.feat_extract.featureset import Featureset
+from transformers import Wav2Vec2FeatureExtractor
+from transformers.models.wav2vec2.modeling_wav2vec2 import Wav2Vec2Model
 
 # import audiofile
 # import torchaudio
@@ -28,7 +28,7 @@ class Wav2vec2(Featureset):
         # load model
         self.util.debug('loading wav2vec model...')
         model_path = self.util.config_val('FEATS', 'wav2vec.model', 'facebook/wav2vec2-large-robust-ft-swbd-300h')
-        self.processor = transformers.Wav2Vec2Processor.from_pretrained(model_path)
+        self.processor = Wav2Vec2FeatureExtractor.from_pretrained(model_path)
         self.model = Wav2Vec2Model.from_pretrained(model_path).to(self.device)
         print(f'intialized vec model on {self.device}')
         self.model.eval()

--- a/nkululeko/feature_extractor.py
+++ b/nkululeko/feature_extractor.py
@@ -5,8 +5,9 @@ Helper class to encapsulate feature extraction methods
 
 """
 import pandas as pd
-from nkululeko.util import Util 
+
 from nkululeko.feat_extract.feats_opensmile import Opensmileset
+from nkululeko.util import Util
 
 
 class FeatureExtractor:
@@ -16,79 +17,121 @@ class FeatureExtractor:
         data_df (pandas.DataFrame): dataframe with audiofile paths as index
         feats_types (array of strings): designations of acoustic feature extractors to be used
         data_name (string): names of databases that are extracted (for the caching)
-        feats_designation (string): the type of split (train/test), also is used for the cache name.    
+        feats_designation (string): the type of split (train/test), also is used for the cache name.
     Returns:
-        df (pandas.DataFrame): dataframe with same index as data_df and acoustic features in columns  
+        df (pandas.DataFrame): dataframe with same index as data_df and acoustic features in columns
     """
-    df = None # pandas dataframe to store the features (and indexed with the data from the sets)
-    data_df = None # dataframe to get audio paths
 
-# def __init__
+    # pandas dataframe to store the features (and indexed with the data from the sets)
+    df = None
+    data_df = None  # dataframe to get audio paths
+
+    # def __init__
     def __init__(self, data_df, feats_types, data_name, feats_designation):
         self.data_df = data_df
         self.data_name = data_name
         self.feats_types = feats_types
-        self.util = Util('feature_extractor')
+        self.util = Util("feature_extractor")
         self.feats_designation = feats_designation
-    
+
     def extract(self):
         # feats_types = self.util.config_val_list('FEATS', 'type', ['os'])
         self.featExtractor = None
-        self.feats= pd.DataFrame()
+        self.feats = pd.DataFrame()
         _scale = True
         for feats_type in self.feats_types:
-            store_name = f'{self.data_name}_{feats_type}'   
-            if feats_type=='os':
-                self.featExtractor = Opensmileset(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='trill':
+            store_name = f"{self.data_name}_{feats_type}"
+            if feats_type == "os":
+                self.featExtractor = Opensmileset(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "trill":
                 from nkululeko.feat_extract.feats_trill import TRILLset
-                self.featExtractor = TRILLset(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='wav2vec':
+                self.featExtractor = TRILLset(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "wav2vec":
                 from nkululeko.feat_extract.feats_wav2vec2 import Wav2vec2
-                self.featExtractor = Wav2vec2(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='audmodel':
+                self.featExtractor = Wav2vec2(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type in ("hubert", "hubert_ft", "hubert_large", 
+                                "hubert_large", "hubert_xlarge", "hubert_xlarge_ft"):
+                from nkululeko.feat_extract.feats_hubert import Hubert
+                self.featExtractor = Hubert(
+                    f"{store_name}_{self.feats_designation}", self.data_df,
+                    feats_type
+                )
+ 
+            elif feats_type == "audmodel":
                 from nkululeko.feat_extract.feats_audmodel import AudModelSet
-                self.featExtractor = AudModelSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='auddim':
-                from nkululeko.feat_extract.feats_audmodel_dim import AudModelDimSet
-                self.featExtractor = AudModelDimSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='agender':
-                from nkululeko.feat_extract.feats_agender import AudModelAgenderSet
-                self.featExtractor = AudModelAgenderSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='agender_agender':
-                from nkululeko.feat_extract.feats_agender_agender import AgenderAgenderSet
-                self.featExtractor = AgenderAgenderSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='snr':
+                self.featExtractor = AudModelSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "auddim":
+                from nkululeko.feat_extract.feats_audmodel_dim import \
+                    AudModelDimSet
+                self.featExtractor = AudModelDimSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "agender":
+                from nkululeko.feat_extract.feats_agender import \
+                    AudModelAgenderSet
+                self.featExtractor = AudModelAgenderSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "agender_agender":
+                from nkululeko.feat_extract.feats_agender_agender import \
+                    AgenderAgenderSet
+                self.featExtractor = AgenderAgenderSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "snr":
                 from nkululeko.feat_extract.feats_snr import SNRSet
-                self.featExtractor = SNRSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='mos':
+                self.featExtractor = SNRSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "mos":
                 from nkululeko.feat_extract.feats_mos import MOSSet
-                self.featExtractor = MOSSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='squim':
+                self.featExtractor = MOSSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "squim":
                 from nkululeko.feat_extract.feats_squim import SQUIMSet
-                self.featExtractor = SQUIMSet(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='clap':
+                self.featExtractor = SQUIMSet(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "clap":
                 from nkululeko.feat_extract.feats_clap import Clap
-                self.featExtractor = Clap(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='praat':
+                self.featExtractor = Clap(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "praat":
                 from nkululeko.feat_extract.feats_praat import Praatset
-                self.featExtractor = Praatset(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='mld':
+                self.featExtractor = Praatset(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "mld":
                 from nkululeko.feat_extract.feats_mld import MLD_set
-                self.featExtractor = MLD_set(f'{store_name}_{self.feats_designation}', self.data_df)
-            elif feats_type=='import':
+                self.featExtractor = MLD_set(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
+            elif feats_type == "import":
                 from nkululeko.feat_extract.feats_import import Importset
-                self.featExtractor = Importset(f'{store_name}_{self.feats_designation}', self.data_df)
+                self.featExtractor = Importset(
+                    f"{store_name}_{self.feats_designation}", self.data_df
+                )
             else:
-                self.util.error(f'unknown feats_type: {feats_type}')
+                self.util.error(f"unknown feats_type: {feats_type}")
 
             self.featExtractor.extract()
             self.featExtractor.filter()
             # remove samples that were not extracted by MLD
-            #self.df_test = self.df_test.loc[self.df_test.index.intersection(featExtractor_test.df.index)]
-            #self.df_train = self.df_train.loc[self.df_train.index.intersection(featExtractor_train.df.index)]
-            self.util.debug(f'{feats_type}: shape : {self.featExtractor.df.shape}')
-            self.feats = pd.concat([self.feats, self.featExtractor.df], axis = 1)
+            # self.df_test = self.df_test.loc[self.df_test.index.intersection(featExtractor_test.df.index)]
+            # self.df_train = self.df_train.loc[self.df_train.index.intersection(featExtractor_train.df.index)]
+            self.util.debug(
+                f"{feats_type}: shape : {self.featExtractor.df.shape}")
+            self.feats = pd.concat([self.feats, self.featExtractor.df], axis=1)
         return self.feats
 
     def extract_sample(self, signal, sr):


### PR DESCRIPTION
This adds five variants of Hubert: `hubert`, `hubert_ft`, `hubert_large`, `hubert_xlarge`, and `hubert_xlarge_ft. Here are the results of the first four variants on RAVDESS dataset. This PR related to #56 

```bash
# Hubert (base)
UG modelrunner: run: 0 epoch: 0: result: test: 0.742 UAR
DEBUG modelrunner: plotting confusion matrix to train_test_dev_svm_hubert__0_000_cnf
DEBUG runmanager: value for measure not found, using default: uar
DEBUG reporter: labels: ['angry' 'happy' 'neutral' 'sad']
DEBUG reporter: result per class (F1 score): [0.909, 0.8, 0.4, 0.849]
WARNING experiment: Save experiment: Can't pickle local object: Serialization of parametrized modules is only supported through state_dict(). See:
https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-a-general-checkpoint-for-inference-and-or-resuming-training
DEBUG experiment: Done, used 694.146 seconds
DONE
---
# Hubert_ft (finetuning)

DEBUG modelrunner: run: 0 epoch: 0: result: test: 0.891 UAR
DEBUG modelrunner: plotting confusion matrix to train_test_dev_svm_hubert__0_000_cnf
DEBUG runmanager: value for measure not found, using default: uar
DEBUG reporter: labels: ['angry' 'happy' 'neutral' 'sad']
DEBUG reporter: result per class (F1 score): [0.935, 0.814, 0.842, 0.892]
WARNING experiment: Save experiment: Can't pickle local object: Serialization of parametrized modules is only supported through state_dict(). See:
https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-a-general-checkpoint-for-inference-and-or-resuming-training
DEBUG experiment: Done, used 1998.011 seconds
DONE
-----
# Hubert_large

DEBUG modelrunner: run: 0 epoch: 0: result: test: 0.914 UAR
DEBUG modelrunner: plotting confusion matrix to train_test_dev_svm_hubert_large_ll60k__0_000_cnf
DEBUG runmanager: value for measure not found, using default: uar
DEBUG reporter: labels: ['angry' 'happy' 'neutral' 'sad']
DEBUG reporter: result per class (F1 score): [0.984, 0.881, 0.882, 0.882]
WARNING experiment: Save experiment: Can't pickle local object: Serialization of parametrized modules is only supported through state_dict(). See:
https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-a-general-checkpoint-for-inference-and-or-resuming-training
DEBUG experiment: Done, used 1867.607 seconds
DONE
---
# Hubert_xlarge
DEBUG modelrunner: run: 0 epoch: 0: result: test: 0.852 UAR
DEBUG modelrunner: plotting confusion matrix to train_test_dev_svm_hubert_xlarge__0_000_cnf
DEBUG runmanager: value for measure not found, using default: uar
DEBUG reporter: labels: ['angry' 'happy' 'neutral' 'sad']
DEBUG reporter: result per class (F1 score): [0.899, 0.821, 0.788, 0.879]
WARNING experiment: Save experiment: Can't pickle local object: Serialization of parametrized modules is only supported through state_dict(). See:
https://pytorch.org/tutorials/beginner/saving_loading_models.html#saving-loading-a-general-checkpoint-for-inference-and-or-resuming-training
DEBUG experiment: Done, used 4410.192 seconds
```

I also modified the wav2vec feature file to adopt the style introduced in this PR, so it will be able to receive variants of wav2vec2 (not done yet).

Example of INI file for Ravdess (nkululeko.nkululeko)
```INI
[EXP]
root = ./
name = results/exp_ravdess_hubert
runs = 1
epochs = 1
save = True
[DATA]
databases = ['train', 'test', 'dev']
train = ./data/ravdess/ravdess_train.csv
train.type = csv
train.absolute_path = False
train.split_strategy = train
dev = ./data/ravdess/ravdess_dev.csv
dev.type = csv
dev.absolute_path = False
dev.split_strategy = train
test = ./data/ravdess/ravdess_test.csv
test.type = csv
test.absolute_path = False
test.split_strategy = test
target = emotion
labels = ['angry', 'happy', 'neutral', 'sad']
[FEATS]
type = ['hubert_xlarge']
scale = standard
[MODEL]
type = svm
```