### PR TITLE
improve demo_predictor to handle folder

### DIFF
--- a/nkululeko/demo_predictor.py
+++ b/nkululeko/demo_predictor.py
@@ -59,9 +59,13 @@ class Demo_predictor:
                     sig, sr = audiofile.read(file_path)
                     print(f"predicting file {file_path}")
                     res_dict = self.predict_signal(sig, sr)
-                    df_tmp = pd.DataFrame(res_dict, index=[file_path])
+                    df_tmp = pd.DataFrame(res_dict, index=[file_name])
                     df_res = pd.concat([df_res, df_tmp], ignore_index=False)
                 df_res = df_res.set_index(df_res.index.rename("file"))
+                # save only filename and prediction (df_tmp) by default
+                # drop other columns
+                df_res = df_res[["predicted"]]
+
                 if self.outfile is not None:
                     df_res.to_csv(self.outfile)
                 else:

--- a/nkululeko/demo_predictor.py
+++ b/nkululeko/demo_predictor.py
@@ -1,7 +1,10 @@
-import pandas as pd
-import numpy as np
-import audiofile
+import os
+
 import audformat
+import audiofile
+import numpy as np
+import pandas as pd
+
 import nkululeko.glob_conf as glob_conf
 from nkululeko.utils.util import Util
 
@@ -52,7 +55,7 @@ class Demo_predictor:
                                 file_list.append(line)
                 for file_name in file_list:
                     test_folder = glob_conf.config["DATA"]["test_folder"]
-                    file_path = test_folder + file_name.strip()
+                    file_path = os.path.join(test_folder, file_name.strip())
                     sig, sr = audiofile.read(file_path)
                     print(f"predicting file {file_path}")
                     res_dict = self.predict_signal(sig, sr)


### PR DESCRIPTION
Change `+` to `os.path.join`. This will solve errors if no trailing slash is given for the `--folder` argument. (e.g., `--folder data/ravdess` instead of `--folder data/ravdess/`)