### PR TITLE
Make base model for finetuning as variable for INI file

### DIFF
--- a/ini_file.md
+++ b/ini_file.md
@@ -303,8 +303,8 @@
   * device = cpu
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5
-* **model_ckpt**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work.
-  * model_ckpt = microsoft/wavlm-base
+* **pretrained_model**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work.
+  * pretrained_model = microsoft/wavlm-base
 
 ### EXPL
 * **model**: Which model to use to estimate feature importance.

--- a/ini_file.md
+++ b/ini_file.md
@@ -303,6 +303,8 @@
   * device = cpu
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5
+* **model_ckpt**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work.
+  * model_ckpt = microsoft/wavlm-base
 
 ### EXPL
 * **model**: Which model to use to estimate feature importance.

--- a/ini_file.md
+++ b/ini_file.md
@@ -299,7 +299,7 @@
   * batch_size = 8
 * **num_workers**: Number of parallel processes for neural nets
   * num_workers = 5
-* **device**: For torch/huggingface models: select your GPU if you have one. Values are either "cpu" or GPU ids (e.g., 0, 1 or both "0,1"). By default, the GPU/CUDA is used if available, otherwise is CPU.
+* **device**: For torch/huggingface models: select your GPU number if you have one. Values are either "cpu" or GPU ids (e.g., 0, 1 or both "0,1"). By default, the GPU/CUDA is used if available, otherwise is CPU.
   * device = 0
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5

--- a/ini_file.md
+++ b/ini_file.md
@@ -305,7 +305,7 @@
   * device_id = 0
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5
-* **pretrained_model**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work.
+* **pretrained_model**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work. Default is facebook/wav2vec2-large-robust-ft-swbd-300h. 
   * pretrained_model = microsoft/wavlm-base
 
 ### EXPL

--- a/ini_file.md
+++ b/ini_file.md
@@ -299,10 +299,8 @@
   * batch_size = 8
 * **num_workers**: Number of parallel processes for neural nets
   * num_workers = 5
-* **device**: For torch/huggingface models: select your GPU if you have one. Values are either "cpu" or "cuda".
-  * device = cpu
-* **device_ids**: For torch/huggingface models: select your GPU if you have multiple. Values are GPU ids (0, 1 or both "0,1").
-  * device_id = 0
+* **device**: For torch/huggingface models: select your GPU if you have one. Values are either "cpu" or GPU ids (e.g., 0, 1 or both "0,1"). By default, the GPU/CUDA is used if available, otherwise is CPU.
+  * device = 0
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5
 * **pretrained_model**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work. Default is facebook/wav2vec2-large-robust-ft-swbd-300h. 

--- a/ini_file.md
+++ b/ini_file.md
@@ -299,8 +299,10 @@
   * batch_size = 8
 * **num_workers**: Number of parallel processes for neural nets
   * num_workers = 5
-* **device**: For torch/huggingface models: select your GPU if you have one
+* **device**: For torch/huggingface models: select your GPU if you have one. Values are either "cpu" or "cuda".
   * device = cpu
+* **device_ids**: For torch/huggingface models: select your GPU if you have multiple. Values are GPU ids (0, 1 or both "0,1").
+  * device_id = 0
 * **patience**: Number of epochs to wait if the result gets better (for early stopping)
   * patience = 5
 * **pretrained_model**: Base model for finetuning/transfer learning. Variants of wav2vec2, Hubert, and WavLM are tested to work.

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -42,9 +42,9 @@ class TunedModel(BaseModel):
         self.device = "cuda:0" if torch.cuda.is_available() else "cpu"
         self.batch_size = int(self.util.config_val("MODEL", "batch_size", "8"))
         if self.device != "cpu":
-            self.util.debug(f"running on device {device}")
+            self.util.debug(f"running on device {self.device}")
             os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-            os.environ["CUDA_VISIBLE_DEVICES"] = self.device
+            os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # self.device
         self.df_train, self.df_test = df_train, df_test
         self.epoch_num = int(self.util.config_val("EXP", "epochs", 1))
 

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -21,8 +21,6 @@ from transformers.models.wav2vec2.modeling_wav2vec2 import (
     Wav2Vec2PreTrainedModel,
 )
 
-from transformers import AutoConfig, AutoModel
-
 import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model as BaseModel
 from nkululeko.reporting.reporter import Reporter
@@ -43,11 +41,11 @@ class TunedModel(BaseModel):
         # device = self.util.config_val("MODEL", "device", "cpu")
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.batch_size = int(self.util.config_val("MODEL", "batch_size", "8"))
-        self.device_id = self.util.config_val("MODEL", "device_id", "0")
+        # self.device_id = self.util.config_val("MODEL", "device_id", "0")
         if self.device != "cpu":
             self.util.debug(f"running on device {self.device}")
             os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-            os.environ["CUDA_VISIBLE_DEVICES"] = self.device_id  # self.device
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.device  # self.device
         self.df_train, self.df_test = df_train, df_test
         self.epoch_num = int(self.util.config_val("EXP", "epochs", 1))
 
@@ -55,12 +53,13 @@ class TunedModel(BaseModel):
 
     def _init_model(self):
         model_path = "facebook/wav2vec2-large-robust-ft-swbd-300h"
-        pretrained_model = self.util.config_val("MODEL", "pretrained_model", model_path)
+        pretrained_model = self.util.config_val(
+            "MODEL", "pretrained_model", model_path)
         self.num_layers = None
         self.sampling_rate = 16000
         self.max_duration_sec = 8.0
         self.accumulation_steps = 4
-        
+
         # print finetuning information via debug
         self.util.debug(f"Finetuning from model: {pretrained_model}")
 
@@ -382,7 +381,7 @@ class Model(Wav2Vec2PreTrainedModel):
             setattr(config, 'add_adapter', False)
 
         super().__init__(config)
-        
+
         self.wav2vec2 = Wav2Vec2Model(config)
         self.cat = ModelHead(config)
         self.init_weights()

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -54,14 +54,14 @@ class TunedModel(BaseModel):
 
     def _init_model(self):
         model_path = "facebook/wav2vec2-large-robust-ft-swbd-300h"
-        model_ckpt = self.util.config_val("MODEL", "model_ckpt", model_path)
+        pretrained_model = self.util.config_val("MODEL", "pretrained_model", model_path)
         self.num_layers = None
         self.sampling_rate = 16000
         self.max_duration_sec = 8.0
         self.accumulation_steps = 4
         
         # print finetuning information via debug
-        self.util.debug(f"Finetuning from model: {model_ckpt}")
+        self.util.debug(f"Finetuning from model: {pretrained_model}")
 
         # create dataset
         dataset = {}
@@ -92,7 +92,7 @@ class TunedModel(BaseModel):
             value in target_mapping.items()}
 
         self.config = transformers.AutoConfig.from_pretrained(
-            model_ckpt,
+            pretrained_model,
             num_labels=len(target_mapping),
             label2id=target_mapping,
             id2label=target_mapping_reverse,
@@ -124,7 +124,7 @@ class TunedModel(BaseModel):
         assert self.processor.feature_extractor.sampling_rate == self.sampling_rate
 
         self.model = Model.from_pretrained(
-            model_ckpt,
+            pretrained_model,
             config=self.config,
         )
         self.model.freeze_feature_extractor()

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -43,10 +43,11 @@ class TunedModel(BaseModel):
         # device = self.util.config_val("MODEL", "device", "cpu")
         self.device = "cuda" if torch.cuda.is_available() else "cpu"
         self.batch_size = int(self.util.config_val("MODEL", "batch_size", "8"))
+        self.device_id = self.util.config_val("MODEL", "device_id", "0")
         if self.device != "cpu":
             self.util.debug(f"running on device {self.device}")
             os.environ["CUDA_DEVICE_ORDER"] = "PCI_BUS_ID"
-            os.environ["CUDA_VISIBLE_DEVICES"] = "0"  # self.device
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.device_id  # self.device
         self.df_train, self.df_test = df_train, df_test
         self.epoch_num = int(self.util.config_val("EXP", "epochs", 1))
 

--- a/tests/exp_emodb_finetune.ini
+++ b/tests/exp_emodb_finetune.ini
@@ -1,6 +1,6 @@
 [EXP]
 root = ./tests/results/
-name = test_pretrain
+name = test_pretrain_1
 runs = 1
 epochs = 10
 save = True

--- a/tests/exp_emodb_finetune.ini
+++ b/tests/exp_emodb_finetune.ini
@@ -18,4 +18,4 @@ type = []
 type = finetune
 device = 1
 batch_size = 8
-model_ckpt = microsoft/wavlm-base
+pretrained_model = microsoft/wavlm-base

--- a/tests/exp_emodb_finetune.ini
+++ b/tests/exp_emodb_finetune.ini
@@ -18,3 +18,4 @@ type = []
 type = finetune
 device = 1
 batch_size = 8
+model_ckpt = microsoft/wavlm-base


### PR DESCRIPTION
With this PR, related to #117, I modified model_tuned.py so the base model can be configured in the INI file.
New value for INI file:

```
pretrained_model = microsoft/wavlm-base
```

Without specifying `pretrained_model`, the default `facebook/wav2vec2-large-robust-ft-swbd-300h` will be used. Example of results
```
# wav2vec2 large robust swbd (default)
DEBUG reporter: epoch: 10, UAR: .46, (+-.422/.496), ACC: .515
DEBUG reporter: labels: ['happiness', 'neutral', 'anger', 'sadness', 'fear', 'boredom', 'disgust']
DEBUG reporter: result per class (F1 score): [0.625, 0.508, 0.074, 0.0, 0.0, 0.568, 0.929]
WARNING experiment: Save experiment: Can't pickle the trained model so saving without it. (it should be stored anyway)
DEBUG experiment: Done, used 1633.975 seconds
# model_ckpt = facebook/hubert-large-ll60k
BUG reporter: epoch: 10, UAR: .633, (+-.589/.681), ACC: .662
DEBUG reporter: labels: ['happiness', 'neutral', 'anger', 'sadness', 'fear', 'boredom', 'disgust']
DEBUG reporter: result per class (F1 score): [0.743, 0.536, 0.8, 0.533, 0.054, 0.712, 0.897]
WARNING experiment: Save experiment: Can't pickle the trained model so saving without it. (it should be stored anyway)
DEBUG experiment: Done, used 1629.633 seconds
# model_ckpt = microsoft/wavlm-base
BUG reporter: epoch: 10, UAR: .802, (+-.753/.843), ACC: .826
DEBUG reporter: labels: ['happiness', 'neutral', 'anger', 'sadness', 'fear', 'boredom', 'disgust']
DEBUG reporter: result per class (F1 score): [0.824, 0.861, 0.92, 0.871, 0.316, 0.852, 0.982]
WARNING experiment: Save experiment: Can't pickle the trained model so saving without it. (it should be stored anyway)
DEBUG experiment: Done, used 758.234 seconds
```