### PR TITLE
fix mlp did not reporting the best

### DIFF
--- a/nkululeko/reporting/reporter.py
+++ b/nkululeko/reporting/reporter.py
@@ -225,7 +225,7 @@ class Reporter:
 
         res_dir = self.util.get_path("res_dir")
         rpt = (
-            f"epoch: {epoch}, UAR: {uar_str}"
+            f"Best score at epoch: {epoch}, UAR: {uar_str}"
             + f", (+-{up_str}/{low_str}), ACC: {acc_str}"
         )
         # print(rpt)
@@ -262,12 +262,12 @@ class Reporter:
                     c_res = rpt[l]["f1-score"]
                     c_ress[i] = float(f"{c_res:.3f}")
                 self.util.debug(f"labels: {labels}")
-                f1_per_class = f"result per class (F1 score): {c_ress}"
+                f1_per_class = f"result per class (F1 score): {c_ress} from epoch: {epoch}"
                 if len(np.unique(self.truths)) == 2:
                     fpr, tpr, _ = roc_curve(self.truths, self.preds)
                     auc_score = auc(fpr, tpr)
                     pauc_score = roc_auc_score(self.truths, self.preds, max_fpr=0.1)
-                    auc_pauc = f"auc: {auc_score:.3f}, pauc: {pauc_score:.3f}"
+                    auc_pauc = f"auc: {auc_score:.3f}, pauc: {pauc_score:.3f} from epoch: {epoch}"
                     self.util.debug(auc_pauc)
                 self.util.debug(f1_per_class)
                 rpt_str = f"{json.dumps(rpt)}\n{f1_per_class}"

--- a/nkululeko/runmanager.py
+++ b/nkululeko/runmanager.py
@@ -107,9 +107,10 @@ class Runmanager:
                 )
                 self.print_model(best_report, plot_name)
             # finally, print out the numbers for this run
-            self.reports[-1].print_results(
-                int(self.util.config_val("EXP", "epochs", 1))
-            )
+            # self.reports[-1].print_results(
+            #     int(self.util.config_val("EXP", "epochs", 1))
+            # )
+            best_report.print_results(best_report.epoch)
             self.best_results.append(best_report)
             self.last_epochs.append(last_epoch)
 
@@ -152,7 +153,7 @@ class Runmanager:
             report: for which report (will be computed newly from model)
             plot_name: name of plot file
         """
-        epoch = report.epoch
+        epoch = report.best_epoch
         # self.load_model(report)
         # report = self.model.predict()
         self.util.debug(f"plotting conf matrix to {plot_name}")

--- a/tests/exp_emodb_finetune.ini
+++ b/tests/exp_emodb_finetune.ini
@@ -1,8 +1,8 @@
 [EXP]
-root = ./tests/results/
-name = finetuned_1
+root = ./tmp/
+name = finetuned
 runs = 1
-epochs = 10
+epochs = 5
 save = True
 [DATA]
 databases = ['emodb']
@@ -18,4 +18,4 @@ type = []
 type = finetune
 ; device = cpu
 batch_size = 4
-; pretrained_model = microsoft/wavlm-base
+pretrained_model = microsoft/wavlm-base


### PR DESCRIPTION
This fix MLP did not report the best metrics at the end of training #130 .
Before PR:

```bash
EBUG runmanager: run 0                                                         
DEBUG model: value for loss not found, using default: cross                     
DEBUG model: using model with cross entropy loss function                       
DEBUG model: value for device not found, using default: cuda                    
DEBUG model: using layers {'l1':128, 'l2':64}                                   
DEBUG model: value for learning_rate not found, using default: 0.0001           
DEBUG model: value for num_workers not found, using default: 5                  
DEBUG modelrunner: run: 0 epoch: 0: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 1: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 2: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 3: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 4: result: test: 0.503 UAR                     
DEBUG modelrunner: run: 0 epoch: 5: result: test: 0.509 UAR                     
DEBUG modelrunner: run: 0 epoch: 6: result: test: 0.516 UAR                     
DEBUG modelrunner: run: 0 epoch: 7: result: test: 0.518 UAR                     
DEBUG modelrunner: run: 0 epoch: 8: result: test: 0.521 UAR                     
DEBUG modelrunner: run: 0 epoch: 9: result: test: 0.520 UAR                     
DEBUG modelrunner: run: 0 epoch: 10: result: test: 0.523 UAR                    
DEBUG modelrunner: run: 0 epoch: 11: result: test: 0.522 UAR                    
DEBUG modelrunner: run: 0 epoch: 12: result: test: 0.526 UAR                    
DEBUG modelrunner: run: 0 epoch: 13: result: test: 0.523 UAR                    
DEBUG modelrunner: run: 0 epoch: 14: result: test: 0.521 UAR                    
DEBUG modelrunner: run: 0 epoch: 15: result: test: 0.518 UAR                    
DEBUG modelrunner: run: 0 epoch: 16: result: test: 0.523 UAR                    
DEBUG modelrunner: run: 0 epoch: 17: result: test: 0.526 UAR                    
DEBUG modelrunner: run: 0 epoch: 18: result: test: 0.522 UAR                    
DEBUG modelrunner: run: 0 epoch: 19: result: test: 0.521 UAR                    
DEBUG modelrunner: plotting confusion matrix to train_dev_mlp_os_64-128_scale-st
andard_0_019_cnf                                                                
DEBUG reporter: epoch: 19, UAR: .52, (+-.508/.534), ACC: .961                   
DEBUG reporter: labels: [0, 1]                                                  
DEBUG reporter: auc: 0.521, pauc: 0.520                                         
DEBUG reporter: result per class (F1 score): [0.981, 0.073]       
```
After this PR, all metrics report using the best model at specific epoch, not the last.

```bash
DEBUG modelrunner: run: 0 epoch: 0: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 1: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 2: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 3: result: test: 0.500 UAR                     
DEBUG modelrunner: run: 0 epoch: 4: result: test: 0.502 UAR                     
DEBUG modelrunner: run: 0 epoch: 5: result: test: 0.504 UAR                     
DEBUG modelrunner: run: 0 epoch: 6: result: test: 0.513 UAR                     
DEBUG modelrunner: run: 0 epoch: 7: result: test: 0.517 UAR                     
DEBUG modelrunner: run: 0 epoch: 8: result: test: 0.522 UAR                     
DEBUG modelrunner: run: 0 epoch: 9: result: test: 0.521 UAR                     
DEBUG modelrunner: run: 0 epoch: 10: result: test: 0.525 UAR                    
DEBUG modelrunner: run: 0 epoch: 11: result: test: 0.530 UAR                    
DEBUG modelrunner: run: 0 epoch: 12: result: test: 0.526 UAR                    
DEBUG modelrunner: run: 0 epoch: 13: result: test: 0.529 UAR                    
DEBUG modelrunner: run: 0 epoch: 14: result: test: 0.531 UAR                    
DEBUG modelrunner: run: 0 epoch: 15: result: test: 0.530 UAR                    
DEBUG modelrunner: run: 0 epoch: 16: result: test: 0.530 UAR                    
DEBUG modelrunner: run: 0 epoch: 17: result: test: 0.535 UAR                    
DEBUG modelrunner: run: 0 epoch: 18: result: test: 0.529 UAR                    
DEBUG modelrunner: run: 0 epoch: 19: result: test: 0.528 UAR                    
DEBUG modelrunner: plotting confusion matrix to train_dev_mlp_os_64-128_scale-st
andard_0_019_cnf                                                                
DEBUG reporter: Best score at epoch: 17, UAR: .534, (+-.52/.55), ACC: .965      
DEBUG reporter: labels: [0, 1]                                                  
DEBUG reporter: auc: 0.535, pauc: 0.534 from epoch: 17                          
DEBUG reporter: result per class (F1 score): [0.982, 0.114] from epoch: 17      
WARNING experiment: Save experiment: Can't pickle the trained model so saving wi
thout it. (it should be stored anyway)                                          
DEBUG experiment: Done, used 100.017 seconds                                    
DONE                                            
```

For finetuning, there is no need to find the best epoch since the argument `load_best_model_at_end` is given in training args.