### PR TITLE
add emotion2vec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,6 @@ docs/_static/
 docs/_templates/
 docs/source/
 docs/build/
+
+# agent settings
+AGENT.md

--- a/examples/exp_polish_emotion2vec.ini
+++ b/examples/exp_polish_emotion2vec.ini
@@ -18,7 +18,7 @@ test.split_strategy = test
 target = emotion
 labels = ['anger', 'neutral', 'fear']
 [FEATS]
-type = ['emotion2vec-base']
+type = ['emotion2vec']
 needs_feature_extraction = True
 no_reuse = True
 [MODEL]

--- a/examples/exp_polish_emotion2vec.ini
+++ b/examples/exp_polish_emotion2vec.ini
@@ -1,0 +1,27 @@
+[EXP]
+root = results/
+name = exp_polish_emotion2vec
+[DATA]
+databases = ['train', 'dev', 'test']
+train = ./data/polish/polish_train.csv
+train.type = csv
+train.absolute_path = False
+train.split_strategy = train
+dev = ./data/polish/polish_dev.csv
+dev.type = csv
+dev.absolute_path = False
+dev.split_strategy = train
+test = ./data/polish/polish_test.csv
+test.type = csv
+test.absolute_path = False
+test.split_strategy = test
+target = emotion
+labels = ['anger', 'neutral', 'fear']
+[FEATS]
+type = ['emotion2vec-base']
+needs_feature_extraction = True
+no_reuse = True
+[MODEL]
+type = xgb
+[RESAMPLE]
+replace = True

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -74,7 +74,7 @@ class Emotion2vec(Featureset):
         store = self.util.get_path("store")
         storage = f"{store}{self.name}.pkl"
         extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        no_reuse = self.util.config_val("FEATS", "no_reuse", "False") == "True"
         if extract or no_reuse or not os.path.isfile(storage):
             if not self.model_initialized:
                 self.init_model()

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -1,6 +1,6 @@
 # feats_emotion2vec.py
 # emotion2vec feature extractor for Nkululeko
-# example feat_type = "emotion2vec-large", "emotion2vec-base", "emotion2vec-seed"
+# choices for feat_type = "emotion2vec", "emotion2vec-large", "emotion2vec-base", "emotion2vec-seed"
 
 # requirements:
 # pip install "modelscope>=1.9.5,<2.0.0"
@@ -49,7 +49,7 @@ class Emotion2vec(Featureset):
         # Map feat_type to model names
         model_mapping = {
             "emotion2vec": "iic/emotion2vec_base",
-            "emotion2vec-base": "iic/emotion2vec_plus_base",
+            "emotion2vec-base": "iic/emotion2vec_base_finetuned",
             "emotion2vec-seed": "iic/emotion2vec_plus_seed",
             "emotion2vec-large": "iic/emotion2vec_plus_large",
         }
@@ -86,33 +86,7 @@ class Emotion2vec(Featureset):
             for idx, (file, start, end) in enumerate(
                 tqdm(self.data_df.index.to_list())
             ):
-                # First, load to get sampling_rate
-                _, sampling_rate = torchaudio.load(file, frame_offset=0, num_frames=-1)
-
-                # Calculate offsets in samples
-                start_sample = (
-                    int(start.total_seconds() * sampling_rate)
-                    if hasattr(start, "total_seconds")
-                    else 0
-                )
-                num_samples = (
-                    int((end - start).total_seconds() * sampling_rate)
-                    if hasattr(start, "total_seconds") and hasattr(end, "total_seconds")
-                    else -1
-                )
-
-                # Now load the segment
-                signal, sampling_rate = torchaudio.load(
-                    file, frame_offset=start_sample, num_frames=num_samples
-                )
-
-                # Resample to 16kHz if needed (emotion2vec expects 16kHz)
-                if sampling_rate != 16000:
-                    resampler = torchaudio.transforms.Resample(sampling_rate, 16000)
-                    signal = resampler(signal)
-                    sampling_rate = 16000
-
-                emb = self.get_embeddings(signal, sampling_rate, file)
+                emb = self.extract_embedding(file, start, end)
                 emb_series.iloc[idx] = emb
             self.df = pd.DataFrame(emb_series.values.tolist(), index=self.data_df.index)
             self.df.to_pickle(storage)
@@ -130,32 +104,44 @@ class Emotion2vec(Featureset):
                     f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
                 )
 
-    def get_embeddings(self, signal, sampling_rate, file):
-        """Extract embeddings from raw audio signal."""
+    def extract_embedding(self, file, start, end):
+        """Extract embeddings directly from audio file."""
         try:
-            # Convert tensor to numpy if needed
-            if torch.is_tensor(signal):
+            # Handle segment extraction if needed
+            if hasattr(start, "total_seconds") and hasattr(end, "total_seconds"):
+                # Load audio segment
+                _, sampling_rate = torchaudio.load(file, frame_offset=0, num_frames=-1)
+                start_sample = int(start.total_seconds() * sampling_rate)
+                num_samples = int((end - start).total_seconds() * sampling_rate)
+                signal, sampling_rate = torchaudio.load(
+                    file, frame_offset=start_sample, num_frames=num_samples
+                )
+
+                # Resample to 16kHz if needed
+                if sampling_rate != 16000:
+                    resampler = torchaudio.transforms.Resample(sampling_rate, 16000)
+                    signal = resampler(signal)
+                    sampling_rate = 16000
+
+                # Convert to numpy and save as temporary file
                 signal_np = signal.squeeze().numpy()
+                if signal_np.ndim > 1:
+                    signal_np = signal_np[0]  # Take first channel if stereo
+
+                import tempfile
+                import soundfile as sf
+
+                with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+                    sf.write(tmp_file.name, signal_np, sampling_rate)
+                    audio_path = tmp_file.name
             else:
-                signal_np = signal.squeeze()
-
-            # emotion2vec expects 1D audio array
-            if signal_np.ndim > 1:
-                signal_np = signal_np[0]  # Take first channel if stereo
-
-            # Save temporary wav file for FunASR model
-            import tempfile
-
-            import soundfile as sf
-
-            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
-                sf.write(tmp_file.name, signal_np, sampling_rate)
-                tmp_path = tmp_file.name
+                # Use full file directly
+                audio_path = file
 
             try:
-                # Extract features using FunASR
+                # Extract features using FunASR emotion2vec model
                 res = self.model.generate(
-                    tmp_path, granularity="utterance", extract_embedding=True
+                    audio_path, granularity="utterance", extract_embedding=True
                 )
 
                 # Get the embeddings from the result
@@ -166,30 +152,66 @@ class Emotion2vec(Featureset):
                             embeddings = np.array(embeddings)
                         return embeddings.flatten()
                     else:
-                        # Fallback to emotion predictions if embeddings not available
-                        predictions = res[0].get("text", "")
-                        # Create a simple feature vector from prediction scores
-                        return np.array(
-                            [0.0] * 768
-                        )  # Default size similar to other models
+                        # Fallback to create default embedding
+                        return np.array([0.0] * 768)
                 else:
-                    self.util.error(
-                        f"No result from emotion2vec model for file: {file}"
-                    )
+                    self.util.error(f"No result from emotion2vec model for file: {file}")
                     return np.array([0.0] * 768)
 
             finally:
-                # Clean up temporary file
-                os.unlink(tmp_path)
+                # Clean up temporary file if we created one
+                if hasattr(start, "total_seconds") and hasattr(end, "total_seconds"):
+                    os.unlink(audio_path)
 
         except Exception as e:
             print(f"Error processing {file}: {str(e)}")
             self.util.error(f"couldn't extract file: {file}, error: {str(e)}")
-            return np.array([0.0] * 768)  # Return zero vector on error
+            return np.array([0.0] * 768)
 
     def extract_sample(self, signal, sr):
         """Extract features from a single sample."""
         if not self.model_initialized:
             self.init_model()
-        feats = self.get_embeddings(signal, sr, "no file")
-        return feats
+        
+        # Save signal as temporary file for emotion2vec
+        import tempfile
+        import soundfile as sf
+        
+        try:
+            # Convert tensor to numpy if needed
+            if torch.is_tensor(signal):
+                signal_np = signal.squeeze().numpy()
+            else:
+                signal_np = signal.squeeze()
+                
+            # Handle multi-channel audio
+            if signal_np.ndim > 1:
+                signal_np = signal_np[0]
+                
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+                sf.write(tmp_file.name, signal_np, sr)
+                
+                # Extract using the emotion2vec model
+                res = self.model.generate(
+                    tmp_file.name, granularity="utterance", extract_embedding=True
+                )
+                
+                # Get embeddings from result
+                if isinstance(res, list) and len(res) > 0:
+                    embeddings = res[0].get("feats", None)
+                    if embeddings is not None:
+                        if isinstance(embeddings, list):
+                            embeddings = np.array(embeddings)
+                        return embeddings.flatten()
+                
+                return np.array([0.0] * 768)
+                
+        except Exception as e:
+            print(f"Error in extract_sample: {str(e)}")
+            return np.array([0.0] * 768)
+        finally:
+            # Clean up temporary file
+            try:
+                os.unlink(tmp_file.name)
+            except:
+                pass

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -64,7 +64,7 @@ class Emotion2vec(Featureset):
         try:
             # Initialize the FunASR model for emotion2vec
             self.model = AutoModel(model=model_path)
-            print(f"initialized emotion2vec model: {model_path}")
+            self.util.debug(f"initialized emotion2vec model: {model_path}")
             self.model_initialized = True
         except Exception as e:
             self.util.error(f"Failed to load emotion2vec model: {str(e)}")

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -211,7 +211,8 @@ class Emotion2vec(Featureset):
             return np.array([0.0] * 768)
         finally:
             # Clean up temporary file
-            try:
-                os.unlink(tmp_file.name)
-            except:
-                pass
+            if tmp_file is not None:  # Check if tmp_file was created
+                try:
+                    os.unlink(tmp_file.name)
+                except:
+                    pass

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -58,7 +58,7 @@ class Emotion2vec(Featureset):
         model_path = self.util.config_val(
             "FEATS",
             "emotion2vec.model",
-            model_mapping.get(self.feat_type, "iic/emotion2vec_plus_base"),
+            model_mapping.get(self.feat_type, "iic/emotion2vec_base"),
         )
 
         try:

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -1,0 +1,195 @@
+# feats_emotion2vec.py
+# emotion2vec feature extractor for Nkululeko
+# example feat_type = "emotion2vec-large", "emotion2vec-base", "emotion2vec-seed"
+
+# requirements:
+# pip install "modelscope>=1.9.5,<2.0.0"
+# pip install funasr
+
+import os
+
+import numpy as np
+import pandas as pd
+import torch
+import torchaudio
+from tqdm import tqdm
+
+import nkululeko.glob_conf as glob_conf
+from nkululeko.feat_extract.featureset import Featureset
+
+
+class Emotion2vec(Featureset):
+    """Class to extract emotion2vec embeddings."""
+
+    def __init__(self, name, data_df, feat_type):
+        """Constructor.
+
+        Is_train is needed to distinguish from test/dev sets,
+        because they use the codebook from the training.
+        """
+        super().__init__(name, data_df, feat_type)
+        # check if device is not set, use cuda if available
+        cuda = "cuda" if torch.cuda.is_available() else "cpu"
+        self.device = self.util.config_val("MODEL", "device", cuda)
+        self.model_initialized = False
+        self.feat_type = feat_type
+
+    def init_model(self):
+        # load model
+        self.util.debug("loading emotion2vec model...")
+
+        try:
+            from funasr import AutoModel
+        except ImportError:
+            self.util.error(
+                "FunASR is required for emotion2vec features. "
+                "Please install with: pip install funasr modelscope"
+            )
+
+        # Map feat_type to model names
+        model_mapping = {
+            "emotion2vec": "iic/emotion2vec_base",
+            "emotion2vec-base": "iic/emotion2vec_plus_base",
+            "emotion2vec-seed": "iic/emotion2vec_plus_seed",
+            "emotion2vec-large": "iic/emotion2vec_plus_large",
+        }
+
+        # Get model path from config or use default mapping
+        model_path = self.util.config_val(
+            "FEATS",
+            "emotion2vec.model",
+            model_mapping.get(self.feat_type, "iic/emotion2vec_plus_base"),
+        )
+
+        try:
+            # Initialize the FunASR model for emotion2vec
+            self.model = AutoModel(model=model_path)
+            print(f"initialized emotion2vec model: {model_path}")
+            self.model_initialized = True
+        except Exception as e:
+            self.util.error(f"Failed to load emotion2vec model: {str(e)}")
+
+    def extract(self):
+        """Extract the features or load them from disk if present."""
+        store = self.util.get_path("store")
+        storage = f"{store}{self.name}.pkl"
+        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
+        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        if extract or no_reuse or not os.path.isfile(storage):
+            if not self.model_initialized:
+                self.init_model()
+            self.util.debug(
+                "extracting emotion2vec embeddings, this might take a while..."
+            )
+            emb_series = pd.Series(index=self.data_df.index, dtype=object)
+            length = len(self.data_df.index)
+            for idx, (file, start, end) in enumerate(
+                tqdm(self.data_df.index.to_list())
+            ):
+                # First, load to get sampling_rate
+                _, sampling_rate = torchaudio.load(file, frame_offset=0, num_frames=-1)
+
+                # Calculate offsets in samples
+                start_sample = (
+                    int(start.total_seconds() * sampling_rate)
+                    if hasattr(start, "total_seconds")
+                    else 0
+                )
+                num_samples = (
+                    int((end - start).total_seconds() * sampling_rate)
+                    if hasattr(start, "total_seconds") and hasattr(end, "total_seconds")
+                    else -1
+                )
+
+                # Now load the segment
+                signal, sampling_rate = torchaudio.load(
+                    file, frame_offset=start_sample, num_frames=num_samples
+                )
+
+                # Resample to 16kHz if needed (emotion2vec expects 16kHz)
+                if sampling_rate != 16000:
+                    resampler = torchaudio.transforms.Resample(sampling_rate, 16000)
+                    signal = resampler(signal)
+                    sampling_rate = 16000
+
+                emb = self.get_embeddings(signal, sampling_rate, file)
+                emb_series.iloc[idx] = emb
+            self.df = pd.DataFrame(emb_series.values.tolist(), index=self.data_df.index)
+            self.df.to_pickle(storage)
+            try:
+                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+            except KeyError:
+                pass
+        else:
+            self.util.debug(f"reusing extracted {self.feat_type} embeddings")
+            self.df = pd.read_pickle(storage)
+            if self.df.isnull().values.any():
+                nanrows = self.df.columns[self.df.isna().any()].tolist()
+                print(nanrows)
+                self.util.error(
+                    f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
+                )
+
+    def get_embeddings(self, signal, sampling_rate, file):
+        """Extract embeddings from raw audio signal."""
+        try:
+            # Convert tensor to numpy if needed
+            if torch.is_tensor(signal):
+                signal_np = signal.squeeze().numpy()
+            else:
+                signal_np = signal.squeeze()
+
+            # emotion2vec expects 1D audio array
+            if signal_np.ndim > 1:
+                signal_np = signal_np[0]  # Take first channel if stereo
+
+            # Save temporary wav file for FunASR model
+            import tempfile
+
+            import soundfile as sf
+
+            with tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as tmp_file:
+                sf.write(tmp_file.name, signal_np, sampling_rate)
+                tmp_path = tmp_file.name
+
+            try:
+                # Extract features using FunASR
+                res = self.model.generate(
+                    tmp_path, granularity="utterance", extract_embedding=True
+                )
+
+                # Get the embeddings from the result
+                if isinstance(res, list) and len(res) > 0:
+                    embeddings = res[0].get("feats", None)
+                    if embeddings is not None:
+                        if isinstance(embeddings, list):
+                            embeddings = np.array(embeddings)
+                        return embeddings.flatten()
+                    else:
+                        # Fallback to emotion predictions if embeddings not available
+                        predictions = res[0].get("text", "")
+                        # Create a simple feature vector from prediction scores
+                        return np.array(
+                            [0.0] * 768
+                        )  # Default size similar to other models
+                else:
+                    self.util.error(
+                        f"No result from emotion2vec model for file: {file}"
+                    )
+                    return np.array([0.0] * 768)
+
+            finally:
+                # Clean up temporary file
+                os.unlink(tmp_path)
+
+        except Exception as e:
+            print(f"Error processing {file}: {str(e)}")
+            self.util.error(f"couldn't extract file: {file}, error: {str(e)}")
+            return np.array([0.0] * 768)  # Return zero vector on error
+
+    def extract_sample(self, signal, sr):
+        """Extract features from a single sample."""
+        if not self.model_initialized:
+            self.init_model()
+        feats = self.get_embeddings(signal, sr, "no file")
+        return feats

--- a/nkululeko/feature_extractor.py
+++ b/nkululeko/feature_extractor.py
@@ -75,7 +75,7 @@ class FeatureExtractor:
             return TRILLset
 
         elif feats_type.startswith(
-            ("wav2vec2", "hubert", "wavlm", "spkrec", "whisper", "ast")
+            ("wav2vec2", "hubert", "wavlm", "spkrec", "whisper", "ast", "emotion2vec")
         ):
             return self._get_feat_extractor_by_prefix(feats_type)
 

--- a/nkululeko/runmanager.py
+++ b/nkululeko/runmanager.py
@@ -116,7 +116,16 @@ class Runmanager:
                 + f"_BEST-dev_{best_report.run}_{best_report.epoch:03d}"
             )
             # finally, print out the numbers for this run
-            self.print_report(best_report, plot_name)
+            # self.print_report(best_report, plot_name)
+            # remember the best run
+            # Only print if best_report is not the same as last_report
+            if best_report is not last_report:
+                plot_name = (
+                    self.util.config_val("PLOT", "name", plot_name_suggest)
+                    + f"_BEST-dev_{best_report.run}_{best_report.epoch:03d}"
+                )
+                self.print_report(best_report, plot_name)
+
             self.best_results.append(best_report)
             self.last_epochs.append(last_epoch)
             if self.split3:


### PR DESCRIPTION
This is an attempt to fix #185 

Tested on Polish dataset with the following command and results (see files changed)
```
(.env) bagus:nkululeko (master)$ python3 -m nkululeko.nkululeko --config examples/exp_polish_emotion2vec.ini 
DEBUG: nkululeko: running exp_polish_emotion2vec from config examples/exp_polish_emotion2vec.ini, nkululeko version 0.94.1
DEBUG: dataset: loading train
DEBUG: dataset: value for audio_path not found, using default: ./
DEBUG: dataset: Loaded database train with 270 samples: got targets: True, got speakers: True (3), got sexes: True, got age: False
DEBUG: dataset: converting to segmented index, this might take a while...
DEBUG: dataset: loading dev
DEBUG: dataset: value for audio_path not found, using default: ./
DEBUG: dataset: Loaded database dev with 90 samples: got targets: True, got speakers: True (1), got sexes: True, got age: False
DEBUG: dataset: converting to segmented index, this might take a while...
DEBUG: dataset: loading test
DEBUG: dataset: value for audio_path not found, using default: ./
DEBUG: dataset: Loaded database test with 90 samples: got targets: True, got speakers: True (1), got sexes: True, got age: False
DEBUG: dataset: converting to segmented index, this might take a while...
DEBUG: experiment: target: emotion
DEBUG: experiment: Using target labels (from config): ['anger', 'neutral', 'fear']
DEBUG: experiment: Labels (from database): ['anger', 'fear', 'neutral']
DEBUG: experiment: loaded databases train,dev,test
DEBUG: experiment: reusing previously stored results/exp_polish_emotion2vec/./store/testdf.csv and results/exp_polish_emotion2vec/./store/traindf.csv
DEBUG: experiment: value for type is not found, using default: dummy
DEBUG: experiment: Categories train (nd.array): ['anger' 'fear' 'neutral']
DEBUG: experiment: Categories test (nd.array): ['neutral' 'anger' 'fear']
DEBUG: experiment: 1 speakers in test and 4 speakers in train
DEBUG: experiment: train/test shape: (360, 6)/(90, 6)
DEBUG: featureset: value for n_jobs is not found, using default: 8
DEBUG: featureset: value for device is not found, using default: cpu
DEBUG: featureset: loading emotion2vec model...
DEBUG: featureset: value for emotion2vec.model is not found, using default: iic/emotion2vec_plus_base
DEBUG:nkululeko.utils.util:DEBUG: featureset: value for emotion2vec.model is not found, using default: iic/emotion2vec_plus_base
funasr version: 1.2.6.
Check update of funasr, and it would cost few times. You may disable it by set `disable_update=True` in AutoModel
You are using the latest version of funasr-1.2.6
Downloading Model from https://www.modelscope.cn to directory: /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base
2025-05-23 10:44:01,678 - modelscope - WARNING - Using branch: master as version is unstable, use with caution
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.0.0.weight, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.0.0.bias, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.1.0.weight, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.1.0.bias, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.2.0.weight, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.2.0.bias, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.3.0.weight, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.blocks.3.0.bias, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.proj.weight, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
Warning, miss key in ckpt: modality_encoders.AUDIO.decoder.proj.bias, /home/bagus/.cache/modelscope/hub/models/iic/emotion2vec_plus_base/model.pt
initialized emotion2vec model: iic/emotion2vec_plus_base
DEBUG: featureset: extracting emotion2vec embeddings, this might take a while...
DEBUG:nkululeko.utils.util:DEBUG: featureset: extracting emotion2vec embeddings, this might take a while...
rtf_avg: 0.286: 100%|███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  3.77it/s]
rtf_avg: 0.568: 100%|
...
███████████████████████████████████████████████████████████████████████████████████████| 1/1 [00:00<00:00,  4.19it/s]
100%|█████████████████████████████████████████████████████████████████████████████████████████████████████| 90/90 [00:39<00:00,  2.28it/s]
DEBUG: experiment: All features: train shape : (360, 768), test shape:(90, 768)
DEBUG:nkululeko.utils.util:DEBUG: experiment: All features: train shape : (360, 768), test shape:(90, 768)
DEBUG: experiment: scaler: False
DEBUG:nkululeko.utils.util:DEBUG: experiment: scaler: False
DEBUG: runmanager: value for runs is not found, using default: 1
DEBUG:nkululeko.utils.util:DEBUG: runmanager: value for runs is not found, using default: 1
DEBUG: runmanager: run 0 using model xgb
DEBUG:nkululeko.utils.util:DEBUG: runmanager: run 0 using model xgb
DEBUG: model: value for n_jobs is not found, using default: 8
DEBUG:nkululeko.utils.util:DEBUG: model: value for n_jobs is not found, using default: 8
DEBUG: modelrunner: value for epochs is not found, using default: 1
DEBUG:nkululeko.utils.util:DEBUG: modelrunner: value for epochs is not found, using default: 1
DEBUG: reporter: Saved probabilities to results/exp_polish_emotion2vec/./results/run_0//pred_emotion_xgb_emotion2vec-base.csv
DEBUG:nkululeko.utils.util:DEBUG: reporter: Saved probabilities to results/exp_polish_emotion2vec/./results/run_0//pred_emotion_xgb_emotion2vec-base.csv
DEBUG: plots: {True: 0, 'True-False': 1.056}
DEBUG:nkululeko.utils.util:DEBUG: plots: {True: 0, 'True-False': 1.056}
DEBUG: plots: Saved plot to results/exp_polish_emotion2vec/./images/run_0/../uncertainty_samples_samples.png
DEBUG:nkululeko.utils.util:DEBUG: plots: Saved plot to results/exp_polish_emotion2vec/./images/run_0/../uncertainty_samples_samples.png
DEBUG: modelrunner: run: 0 epoch: 0: result: test: 0.700 UAR
DEBUG:nkululeko.utils.util:DEBUG: modelrunner: run: 0 epoch: 0: result: test: 0.700 UAR
DEBUG: runmanager: value for name is not found, using default: train_dev_test_emotion_xgb_emotion2vec-base
DEBUG:nkululeko.utils.util:DEBUG: runmanager: value for name is not found, using default: train_dev_test_emotion_xgb_emotion2vec-base
DEBUG: runmanager: plotting conf matrix to train_dev_test_emotion_xgb_emotion2vec-base_last_0_000
DEBUG:nkululeko.utils.util:DEBUG: runmanager: plotting conf matrix to train_dev_test_emotion_xgb_emotion2vec-base_last_0_000
DEBUG: reporter: Saved confusion plot to results/exp_polish_emotion2vec/./images/run_0/train_dev_test_emotion_xgb_emotion2vec-base_last_0_000.png
DEBUG:nkululeko.utils.util:DEBUG: reporter: Saved confusion plot to results/exp_polish_emotion2vec/./images/run_0/train_dev_test_emotion_xgb_emotion2vec-base_last_0_000.png
DEBUG: reporter: Confusion matrix result for epoch: 0, UAR: .7, (+-.599/.788), ACC: .7
DEBUG:nkululeko.utils.util:DEBUG: reporter: Confusion matrix result for epoch: 0, UAR: .7, (+-.599/.788), ACC: .7
DEBUG: reporter: ####->train_dev_test_emotion_xgb_emotion2vec-base_last_0_000<-####
DEBUG:nkululeko.utils.util:DEBUG: reporter: ####->train_dev_test_emotion_xgb_emotion2vec-base_last_0_000<-####
DEBUG: reporter: 
               precision    recall  f1-score   support

       anger     0.8846    0.7667    0.8214        30
     neutral     0.6154    0.5333    0.5714        30
        fear     0.6316    0.8000    0.7059        30

    accuracy                         0.7000        90
   macro avg     0.7105    0.7000    0.6996        90
weighted avg     0.7105    0.7000    0.6996        90

DEBUG:nkululeko.utils.util:DEBUG: reporter: 
               precision    recall  f1-score   support

       anger     0.8846    0.7667    0.8214        30
     neutral     0.6154    0.5333    0.5714        30
        fear     0.6316    0.8000    0.7059        30

    accuracy                         0.7000        90
   macro avg     0.7105    0.7000    0.6996        90
weighted avg     0.7105    0.7000    0.6996        90

DEBUG: reporter: labels: ['anger', 'neutral', 'fear']
DEBUG:nkululeko.utils.util:DEBUG: reporter: labels: ['anger', 'neutral', 'fear']
DEBUG: reporter: result per class (F1 score): [0.821, 0.571, 0.706] from epoch: 0
DEBUG:nkululeko.utils.util:DEBUG: reporter: result per class (F1 score): [0.821, 0.571, 0.706] from epoch: 0
DEBUG: runmanager: value for name is not found, using default: train_dev_test_emotion_xgb_emotion2vec-base
DEBUG:nkululeko.utils.util:DEBUG: runmanager: value for name is not found, using default: train_dev_test_emotion_xgb_emotion2vec-base
DEBUG: runmanager: plotting conf matrix to train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000
DEBUG:nkululeko.utils.util:DEBUG: runmanager: plotting conf matrix to train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000
DEBUG: reporter: Saved confusion plot to results/exp_polish_emotion2vec/./images/run_0/train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000.png
DEBUG:nkululeko.utils.util:DEBUG: reporter: Saved confusion plot to results/exp_polish_emotion2vec/./images/run_0/train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000.png
DEBUG: reporter: Confusion matrix result for epoch: 0, UAR: .7, (+-.599/.788), ACC: .7
DEBUG:nkululeko.utils.util:DEBUG: reporter: Confusion matrix result for epoch: 0, UAR: .7, (+-.599/.788), ACC: .7
DEBUG: reporter: ####->train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000<-####
DEBUG:nkululeko.utils.util:DEBUG: reporter: ####->train_dev_test_emotion_xgb_emotion2vec-base_BEST-dev_0_000<-####
DEBUG: reporter: 
               precision    recall  f1-score   support

       anger     0.8846    0.7667    0.8214        30
     neutral     0.6154    0.5333    0.5714        30
        fear     0.6316    0.8000    0.7059        30

    accuracy                         0.7000        90
   macro avg     0.7105    0.7000    0.6996        90
weighted avg     0.7105    0.7000    0.6996        90

DEBUG:nkululeko.utils.util:DEBUG: reporter: 
               precision    recall  f1-score   support

       anger     0.8846    0.7667    0.8214        30
     neutral     0.6154    0.5333    0.5714        30
        fear     0.6316    0.8000    0.7059        30

    accuracy                         0.7000        90
   macro avg     0.7105    0.7000    0.6996        90
weighted avg     0.7105    0.7000    0.6996        90

DEBUG: reporter: labels: ['anger', 'neutral', 'fear']
DEBUG:nkululeko.utils.util:DEBUG: reporter: labels: ['anger', 'neutral', 'fear']
DEBUG: reporter: result per class (F1 score): [0.821, 0.571, 0.706] from epoch: 0
DEBUG:nkululeko.utils.util:DEBUG: reporter: result per class (F1 score): [0.821, 0.571, 0.706] from epoch: 0
DEBUG: experiment: Done, used 669.764 seconds
DEBUG:nkululeko.utils.util:DEBUG: experiment: Done, used 669.764 seconds
DONE
```