### PR TITLE
Fix #186: Rename test files to avoid pytest conflicts

### DIFF
--- a/nkululeko/experiment.py
+++ b/nkululeko/experiment.py
@@ -23,7 +23,7 @@ from nkululeko.plots import Plots
 from nkululeko.reporting.report import Report
 from nkululeko.runmanager import Runmanager
 from nkululeko.scaler import Scaler
-from nkululeko.nkulu_test_predictor import TestPredictor
+from nkululeko.testing_predictor import TestPredictor
 from nkululeko.utils.util import Util
 
 

--- a/nkululeko/nkuluflag.py
+++ b/nkululeko/nkuluflag.py
@@ -5,7 +5,7 @@ import os.path
 import sys
 
 from nkululeko.nkululeko import doit as nkulu
-from nkululeko.nkulu_test import do_it as test_mod
+from nkululeko.testing import do_it as test_mod
 
 
 def doit(cla):

--- a/nkululeko/testing.py
+++ b/nkululeko/testing.py
@@ -1,4 +1,4 @@
-# nkulu_test.py
+# testing.py
 # Just use a database as test
 
 import argparse
@@ -11,7 +11,6 @@ from nkululeko.utils.util import Util
 
 
 def do_it(config_file, outfile):
-
     # test if the configuration file exists
     if not os.path.isfile(config_file):
         print(f"ERROR: no such file: {config_file}")
@@ -43,7 +42,9 @@ def do_it(config_file, outfile):
 
 
 def main(src_dir):
-    parser = argparse.ArgumentParser(description="Call the nkululeko TEST framework.")
+    parser = argparse.ArgumentParser(
+        description="Call the nkululeko TESTING framework."
+    )
     parser.add_argument("--config", default="exp.ini", help="The base configuration")
     parser.add_argument(
         "--outfile",

--- a/nkululeko/testing_predictor.py
+++ b/nkululeko/testing_predictor.py
@@ -1,4 +1,4 @@
-"""nkulu_test_predictor.py.
+"""testing_predictor.py.
 
 Predict targets from a model and save as csv file.
 

--- a/nkululeko/testing_pretrain.py
+++ b/nkululeko/testing_pretrain.py
@@ -1,4 +1,4 @@
-# nkulu_test_pretrain.py
+# testing_pretrain.py
 import argparse
 import configparser
 import json
@@ -151,7 +151,6 @@ def doit(config_file):
     # training
 
     def data_collator(data):
-
         files = [d["file"] for d in data]
         starts = [d["start"] for d in data]
         ends = [d["end"] for d in data]
@@ -190,7 +189,6 @@ def doit(config_file):
         return batch
 
     def compute_metrics(p: transformers.EvalPrediction):
-
         truth_gender = p.label_ids[:, 0].astype(int)
         preds = p.predictions
         preds_gender = np.argmax(preds, axis=1)
@@ -222,7 +220,6 @@ def doit(config_file):
             inputs,
             return_outputs=False,
         ):
-
             targets = inputs.pop("labels").squeeze()
             targets_gender = targets.type(torch.long)
 

--- a/setup.py
+++ b/setup.py
@@ -89,7 +89,7 @@ setup(
             "nkululeko.predict=nkululeko.predict:main",
             "nkululeko.resample=nkululeko.resample:main",
             "nkululeko.segment=nkululeko.segment:main",
-            "nkululeko.test=nkululeko.nkulu_test:main",
+            "nkululeko.testing=nkululeko.testing:main",
             "nkululeko.ensemble=nkululeko.ensemble:main",
         ],
     },


### PR DESCRIPTION
- Rename test.py to testing.py
- Rename test_pretrain.py to testing_pretrain.py
- Rename test_predictor.py to testing_predictor.py
- Update import statements in nkuluflag.py and experiment.py
- Update setup.py entry point for testing module
- Update internal module references and docstrings

This prevents pytest from automatically discovering these files as test cases,
resolving naming conflicts with the test discovery mechanism.
The existing unit test structure in tests/ and models/tests/ directories
remains unchanged and functional.