### PR TITLE
Add label_smoothing support for cross-entropy loss (#32)

### DIFF
--- a/ini_file.md
+++ b/ini_file.md
@@ -408,6 +408,12 @@ Model and training specifications. In general, default values should work for cl
     * **mse**: Mean squared error (for regression)
     * **mae**: Mean absolute error (for regression)
     * **weighted_bce**: Weighted BinaryCrossEntropyLoss (for imbalanced binary classification)
+* **label_smoothing**: label smoothing for cross-entropy loss. Accepts either a boolean or a float in [0.0, 1.0]. Helps prevent overconfidence and can improve generalization.
+  * label_smoothing = 0.1
+  * Set to `True` to use the default value of 0.1
+  * Set to a float between 0.0 and 1.0 for a custom smoothing factor
+  * Invalid or out-of-range values fall back to 0.0 with a warning
+  * Default: 0.0 (no smoothing)
 * **measure**: A measure/metric to report progress with experiments. For classification, default is UAR. For regression, default is MSE.
   * measure = mse
   * possible values:

--- a/nkululeko/models/model.py
+++ b/nkululeko/models/model.py
@@ -39,6 +39,73 @@ class Model:
         self.xfoldx = self.util.config_val("MODEL", "k_fold_cross", False)
         self.n_jobs = int(self.util.config_val("MODEL", "n_jobs", "8"))
 
+    def _get_label_smoothing(self):
+        """Parse label_smoothing config value for cross-entropy loss.
+
+        Returns 0.0 (no smoothing) by default.
+        Accepts a float in [0.0, 1.0] or the string "true" (shorthand for 0.1).
+        Invalid or out-of-range values fall back to 0.0 with a warning.
+        """
+        ls = self.util.config_val("MODEL", "label_smoothing", "False")
+        ls_str = str(ls).strip().lower()
+
+        # Explicit false/disabled
+        if ls_str in ("false", "no", "none", ""):
+            return 0.0
+
+        # Boolean shorthand "true" → default 0.1
+        if ls_str == "true":
+            self.util.debug("using label smoothing: 0.1 (default)")
+            return 0.1
+
+        # Try to parse as float
+        try:
+            smoothing = float(ls_str)
+        except (ValueError, TypeError):
+            self.util.warn(
+                f"invalid MODEL.label_smoothing value '{ls}', "
+                "falling back to 0.0 (no label smoothing)"
+            )
+            return 0.0
+
+        # Validate range: PyTorch requires 0.0 <= label_smoothing <= 1.0
+        if smoothing < 0.0 or smoothing > 1.0:
+            self.util.warn(
+                f"MODEL.label_smoothing={smoothing} is out of range [0.0, 1.0], "
+                "falling back to 0.0"
+            )
+            return 0.0
+
+        if smoothing > 0.0:
+            self.util.debug(f"using label smoothing: {smoothing}")
+        return smoothing
+
+    def _setup_criterion(self):
+        """Set up the loss criterion from config. Shared by MLP and CNN models.
+
+        Requires self.class_num to be set before calling.
+        Sets self.criterion.
+        Returns the criterion name string for debug logging.
+        """
+        import torch
+
+        from nkululeko.losses.loss_softf1loss import SoftF1Loss
+
+        criterion = self.util.config_val("MODEL", "loss", "cross")
+        if criterion == "cross":
+            label_smoothing = self._get_label_smoothing()
+            self.criterion = torch.nn.CrossEntropyLoss(
+                label_smoothing=label_smoothing,
+            )
+        elif criterion == "f1":
+            self.criterion = SoftF1Loss(
+                num_classes=self.class_num, weight=None, epsilon=1e-7
+            )
+        else:
+            self.util.error(f"unknown loss function: {criterion}")
+        self.util.debug(f"using model with {criterion} loss function")
+        return criterion
+
     def set_model_type(self, type):
         self.model_type = type
 

--- a/nkululeko/models/model_cnn.py
+++ b/nkululeko/models/model_cnn.py
@@ -18,7 +18,6 @@ from sklearn.metrics import recall_score
 from torch.utils.data import Dataset
 
 import nkululeko.glob_conf as glob_conf
-from nkululeko.losses.loss_softf1loss import SoftF1Loss
 from nkululeko.models.model import Model
 from nkululeko.optimizers import get_optimizer
 from nkululeko.reporting.reporter import Reporter
@@ -45,16 +44,7 @@ class CNNModel(Model):
         labels = glob_conf.labels
         self.class_num = len(labels)
         # set up loss criterion
-        criterion = self.util.config_val("MODEL", "loss", "cross")
-        if criterion == "cross":
-            self.criterion = torch.nn.CrossEntropyLoss()
-        elif criterion == "f1":
-            self.criterion = SoftF1Loss(
-                num_classes=self.class_num, weight=None, epsilon=1e-7
-            )
-        else:
-            self.util.error(f"unknown loss function: {criterion}")
-        self.util.debug("using model with cross entropy loss function")
+        self._setup_criterion()
         # set up the model
         # cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", "cpu")

--- a/nkululeko/models/model_mlp.py
+++ b/nkululeko/models/model_mlp.py
@@ -8,7 +8,6 @@ from sklearn.metrics import recall_score
 import torch
 
 import nkululeko.glob_conf as glob_conf
-from nkululeko.losses.loss_softf1loss import SoftF1Loss
 from nkululeko.models.model import Model
 from nkululeko.optimizers import get_optimizer
 from nkululeko.reporting.reporter import Reporter
@@ -39,16 +38,7 @@ class MLPModel(Model):
         labels = glob_conf.labels
         self.class_num = len(labels)
         # set up loss criterion
-        criterion = self.util.config_val("MODEL", "loss", "cross")
-        if criterion == "cross":
-            self.criterion = torch.nn.CrossEntropyLoss()
-        elif criterion == "f1":
-            self.criterion = SoftF1Loss(
-                num_classes=self.class_num, weight=None, epsilon=1e-7
-            )
-        else:
-            self.util.error(f"unknown loss function: {criterion}")
-        self.util.debug("using model with cross entropy loss function")
+        self._setup_criterion()
         activation, act_func = self._get_activation()
         self.util.debug(f"using activation function: {act_func}")
         # set up the model, use GPU if availabe

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -433,6 +433,7 @@ class TunedModel(BaseModel):
         if self.is_classifier:
             criterion = self.util.config_val("MODEL", "loss", "cross")
             if criterion == "cross":
+                label_smoothing = self._get_label_smoothing()
                 if self.util.config_val("MODEL", "class_weight", False):
                     counts = targets[0].value_counts().sort_index()
                     train_weights = 1 / counts
@@ -440,9 +441,12 @@ class TunedModel(BaseModel):
                     self.util.debug(f"train weights: {train_weights}")
                     criterion = torch.nn.CrossEntropyLoss(
                         weight=torch.Tensor(train_weights).to("cuda"),
+                        label_smoothing=label_smoothing,
                     )
                 else:
-                    criterion = torch.nn.CrossEntropyLoss()
+                    criterion = torch.nn.CrossEntropyLoss(
+                        label_smoothing=label_smoothing,
+                    )
             else:
                 self.util.error(f"criterion {criterion} not supported for classifier")
         else:

--- a/tests/test_label_smoothing.py
+++ b/tests/test_label_smoothing.py
@@ -1,0 +1,146 @@
+"""Unit tests for label_smoothing config parsing in the base Model class."""
+
+import configparser
+import tempfile
+
+import pytest
+import torch
+
+import nkululeko.glob_conf as glob_conf
+from nkululeko.models.model import Model
+from nkululeko.utils.util import Util
+
+
+@pytest.fixture(autouse=True)
+def _restore_glob_conf():
+    """Save and restore glob_conf state to prevent test leakage."""
+    orig_config = getattr(glob_conf, "config", None)
+    orig_labels = getattr(glob_conf, "labels", None)
+    yield
+    glob_conf.config = orig_config
+    glob_conf.labels = orig_labels
+
+
+def _make_config(label_smoothing=None, loss="cross", tmp_dir=None):
+    """Helper to create a minimal config for model tests."""
+    config = configparser.ConfigParser()
+    model_section = {"loss": loss, "layers": "[64]"}
+    if label_smoothing is not None:
+        model_section["label_smoothing"] = str(label_smoothing)
+    config["MODEL"] = model_section
+    config["DATA"] = {"target": "emotion"}
+    root = tmp_dir if tmp_dir else tempfile.mkdtemp(prefix="nkululeko_test_")
+    config["EXP"] = {"root": root, "name": "test_ls"}
+    return config
+
+
+def _make_model_stub(label_smoothing=None, tmp_dir=None):
+    """Return a Model instance with only the attributes needed by _get_label_smoothing.
+
+    Uses ``object.__new__`` to bypass ``Model.__init__``, which requires
+    train/test dataframes that are unnecessary for this unit test.
+    """
+    config = _make_config(label_smoothing=label_smoothing, tmp_dir=tmp_dir)
+    glob_conf.config = config
+    glob_conf.labels = ["anger", "neutral", "happy"]
+    model = object.__new__(Model)
+    model.util = Util("test")
+    return model
+
+
+class TestLabelSmoothingParsing:
+    """Test the _get_label_smoothing helper defined on the base Model class."""
+
+    def test_default_no_smoothing(self, tmp_path):
+        model = _make_model_stub(tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+    def test_true_returns_01(self, tmp_path):
+        model = _make_model_stub(label_smoothing="True", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.1)
+
+    def test_lowercase_true_returns_01(self, tmp_path):
+        model = _make_model_stub(label_smoothing="true", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.1)
+
+    def test_string_one_returns_numeric(self, tmp_path):
+        """String '1' is parsed as numeric 1.0, which is valid smoothing."""
+        model = _make_model_stub(label_smoothing="1", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(1.0)
+
+    def test_boolean_true_returns_01(self, tmp_path):
+        model = _make_model_stub(label_smoothing=True, tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.1)
+
+    def test_float_value_passed_through(self, tmp_path):
+        model = _make_model_stub(label_smoothing="0.2", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.2)
+
+    def test_zero_returns_zero(self, tmp_path):
+        model = _make_model_stub(label_smoothing="0.0", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+    def test_false_returns_zero(self, tmp_path):
+        model = _make_model_stub(label_smoothing="False", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+    def test_invalid_string_returns_zero(self, tmp_path):
+        """Non-parsable values should fall back to 0.0 with a warning."""
+        model = _make_model_stub(label_smoothing="foo", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+    def test_negative_value_returns_zero(self, tmp_path):
+        """Negative values are out of range and should fall back to 0.0."""
+        model = _make_model_stub(label_smoothing="-0.1", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+    def test_value_above_one_returns_zero(self, tmp_path):
+        """Values > 1.0 are out of range and should fall back to 0.0."""
+        model = _make_model_stub(label_smoothing="2.0", tmp_dir=str(tmp_path))
+        assert model._get_label_smoothing() == pytest.approx(0.0)
+
+
+class TestCrossEntropyWithLabelSmoothing:
+    """Verify that torch.nn.CrossEntropyLoss uses label_smoothing correctly."""
+
+    def test_no_smoothing_default(self):
+        loss_fn = torch.nn.CrossEntropyLoss(label_smoothing=0.0)
+        logits = torch.tensor([[10.0, 0.0, 0.0]])
+        target = torch.tensor([0])
+        loss = loss_fn(logits, target)
+        assert loss.item() < 0.01
+
+    def test_smoothing_increases_loss_on_confident_correct(self):
+        """Label smoothing should increase loss for over-confident correct predictions."""
+        logits = torch.tensor([[10.0, 0.0, 0.0]])
+        target = torch.tensor([0])
+        loss_no_smooth = torch.nn.CrossEntropyLoss(label_smoothing=0.0)(logits, target)
+        loss_smooth = torch.nn.CrossEntropyLoss(label_smoothing=0.1)(logits, target)
+        assert loss_smooth.item() > loss_no_smooth.item()
+
+    def test_smoothing_on_confident_incorrect_prediction(self):
+        """Label smoothing should decrease loss for highly confident incorrect predictions."""
+        logits = torch.tensor([[0.0, 10.0, 0.0]])
+        target = torch.tensor([0])
+        loss_no_smooth = torch.nn.CrossEntropyLoss(label_smoothing=0.0)(logits, target)
+        loss_smooth = torch.nn.CrossEntropyLoss(label_smoothing=0.1)(logits, target)
+        assert loss_smooth.item() < loss_no_smooth.item()
+
+
+class TestSetupCriterionIntegration:
+    """Verify that _setup_criterion wires label_smoothing into CrossEntropyLoss."""
+
+    def test_criterion_has_label_smoothing(self, tmp_path):
+        """Model.criterion should receive the parsed label_smoothing value."""
+        model = _make_model_stub(label_smoothing="0.15", tmp_dir=str(tmp_path))
+        model.class_num = 3
+        model._setup_criterion()
+        assert hasattr(model, "criterion")
+        assert model.criterion.label_smoothing == pytest.approx(0.15)
+
+    def test_criterion_zero_smoothing_by_default(self, tmp_path):
+        """Without label_smoothing config, criterion should use 0.0."""
+        model = _make_model_stub(tmp_dir=str(tmp_path))
+        model.class_num = 3
+        model._setup_criterion()
+        assert model.criterion.label_smoothing == pytest.approx(0.0)


### PR DESCRIPTION
* Initial plan

* Add label_smoothing support for cross-entropy loss in MLP, CNN and TunedModel

Agent-Logs-Url: https://github.com/bagustris/nkululeko/sessions/53b9ae2e-b330-4af0-839f-68fdbc5e32a7



* Fix SonarQube: eliminate duplicate logic and hardcoded /tmp path in tests

Agent-Logs-Url: https://github.com/bagustris/nkululeko/sessions/d2314ff4-7c4a-4bc7-a6a4-fde2c86ca240



* Fix all code quality issues from SonarQube, Sourcery-AI, Copilot, and Codex

- Validate label_smoothing range [0.0, 1.0] with warnings for invalid values
- Parse "1" as numeric 1.0 (not boolean shorthand); only "true" triggers 0.1 default
- Warn on non-parsable config values instead of silently defaulting
- Extract duplicated criterion setup into shared _setup_criterion() method
- Add tests for truthy variants, invalid values, range validation, integration
- Use pytest fixture to restore glob_conf state; use tmp_path for isolation
- Clarify ini_file.md documentation on accepted types (boolean or float)

Agent-Logs-Url: https://github.com/bagustris/nkululeko/sessions/ced631cc-751f-4df4-b8d1-7e1597010c85



* Fix label_smoothing range validation to accept 1.0 (valid per PyTorch docs)

Agent-Logs-Url: https://github.com/bagustris/nkululeko/sessions/ced631cc-751f-4df4-b8d1-7e1597010c85



* fix: replace direct float equality with pytest.approx to fix SonarCloud S1244

SonarCloud flagged 11 instances of direct float equality checks (python:S1244) in the test file, causing the reliability rating to fail the quality gate.



---------