### PR TITLE
add automated binning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.7.8 (26-06-16)
+------------------------
+* added automated binning
+
 Version 1.7.7 (26-06-09)
 ------------------------
 * new features for SPTK: lfcc and cqcc
@@ -8,7 +12,6 @@ Version 1.7.7 (26-06-09)
 * handle multiple name-target combinations in the flags module
 * handle also explore module with flags, beneath nkululeko
 * store statistical results as text
-
 
 Version 1.7.6 (26-06-03)
 ------------------------

--- a/nkululeko/constants.py
+++ b/nkululeko/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.7.7"
+VERSION = "1.7.8"
 SAMPLING_RATE = 16000
 COL_SEX = "gender"
 COL_AGE = "age"

--- a/nkululeko/reporting/reporter.py
+++ b/nkululeko/reporting/reporter.py
@@ -312,7 +312,23 @@ class Reporter:
         if self.cont_to_cat:
             return
         self.cont_to_cat = True
-        bins = ast.literal_eval(glob_conf.config["DATA"]["bins"])
+        # if there are not labels for binning in the config, set default ones and save them to the config to be used later
+        if not self.util.exists_config_val("DATA", "labels"):
+            labels = ["low", "high"]
+            self.util.set_config_val("DATA", "labels", labels)
+            self.util.debug(f"Set default labels for binning: {labels}")
+        # if there are no bins, set them to border points for the labels and save them to the config to be used later
+        try:
+            bins = ast.literal_eval(glob_conf.config["DATA"]["bins"])
+        except (KeyError, ValueError) as e:
+            label_num = len(ast.literal_eval(glob_conf.config["DATA"]["labels"]))
+            vmin, vmax = np.percentile(self.truths, [5, 95])
+            inner_edges = np.linspace(vmin, vmax, label_num + 1)[1:-1]
+            bins = [-np.inf] + inner_edges.tolist() + [np.inf]
+            self.util.debug(
+                f"No valid 'bins' found in config, using {label_num} equidistant bins"
+                f" between p5={vmin:.3f} and p95={vmax:.3f}: {inner_edges.tolist()}"
+            )
         self.truths = np.digitize(self.truths, bins) - 1
         self.preds = np.digitize(self.preds, bins) - 1
 

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -273,6 +273,13 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
             self.config.add_section(section)
             self.config[section][key] = str(value)
 
+    def exists_config_val(self, section, key):
+        try:
+            _ = self.config[section][key]
+            return True
+        except KeyError:
+            return False
+
     def extract_parent_and_name(self, path_str):
         """Extract (parent_dir_name in 2 levels, filename) from a path string."""
         p = Path(path_str)

--- a/tests/test_continuous_to_categorical.py
+++ b/tests/test_continuous_to_categorical.py
@@ -1,0 +1,108 @@
+import configparser
+import tempfile
+import numpy as np
+import pytest
+
+import nkululeko.glob_conf as glob_conf
+
+
+def _make_config(labels=None, bins=None):
+    config = configparser.ConfigParser()
+    config.add_section("EXP")
+    config.set("EXP", "name", "test")
+    config.set("EXP", "root", tempfile.gettempdir())
+    config.set("EXP", "runs", "1")
+    config.set("EXP", "epochs", "1")
+    config.add_section("DATA")
+    config.set("DATA", "target", "valence")
+    if labels is not None:
+        config.set("DATA", "labels", str(labels))
+    if bins is not None:
+        config.set("DATA", "bins", str(bins))
+    config.add_section("MODEL")
+    config.set("MODEL", "type", "xgb")
+    config.add_section("FEATS")
+    config.set("FEATS", "type", "['os']")
+    config.add_section("PLOT")
+    config.add_section("REPORT")
+    return config
+
+
+def _make_reporter(truths, preds, config):
+    glob_conf.init_config(config)
+    from nkululeko.reporting.reporter import Reporter
+    return Reporter(truths, preds, run=0, epoch=0)
+
+
+class TestContinuousToCategoricalExplicitBins:
+    def test_two_explicit_bins(self):
+        config = _make_config(labels=["low", "high"], bins=[-np.inf, 0.5, np.inf])
+        r = _make_reporter([0.2, 0.8, 0.4, 0.6], [0.1, 0.9, 0.3, 0.7], config)
+        r.continuous_to_categorical()
+        np.testing.assert_array_equal(r.truths, [0, 1, 0, 1])
+        np.testing.assert_array_equal(r.preds, [0, 1, 0, 1])
+
+    def test_three_explicit_bins(self):
+        config = _make_config(
+            labels=["low", "mid", "high"],
+            bins=[-np.inf, 0.33, 0.66, np.inf],
+        )
+        r = _make_reporter([0.1, 0.5, 0.9], [0.2, 0.4, 0.8], config)
+        r.continuous_to_categorical()
+        np.testing.assert_array_equal(r.truths, [0, 1, 2])
+        np.testing.assert_array_equal(r.preds, [0, 1, 2])
+
+    def test_idempotent(self):
+        config = _make_config(labels=["low", "high"], bins=[-np.inf, 0.5, np.inf])
+        r = _make_reporter([0.2, 0.8], [0.1, 0.9], config)
+        r.continuous_to_categorical()
+        truths_after_first = r.truths.copy()
+        r.continuous_to_categorical()  # second call must be a no-op
+        np.testing.assert_array_equal(r.truths, truths_after_first)
+
+
+class TestContinuousToCategoricalAutoEquidistant:
+    def test_two_labels_midpoint_split(self):
+        """With 2 labels and uniform data, cut should be at the midpoint."""
+        config = _make_config(labels=["low", "high"])
+        # uniform data 0..1; p5=0.05, p95=0.95, midpoint~0.5
+        data = np.linspace(0, 1, 100)
+        r = _make_reporter(data, data.copy(), config)
+        r.continuous_to_categorical()
+        assert set(r.truths).issubset({0, 1})
+        # lower half → 0, upper half → 1
+        assert r.truths[0] == 0
+        assert r.truths[-1] == 1
+
+    def test_three_labels_equidistant(self):
+        """With 3 labels, bin edges split the p5–p95 range into thirds."""
+        config = _make_config(labels=["low", "mid", "high"])
+        data = np.linspace(0, 1, 200)
+        r = _make_reporter(data, data.copy(), config)
+        r.continuous_to_categorical()
+        assert set(r.truths).issubset({0, 1, 2})
+        assert r.truths[0] == 0
+        assert r.truths[-1] == 2
+
+    def test_outliers_do_not_shift_bins(self):
+        """Values far outside p5–p95 range should land in the outer bins, not alter edges."""
+        config = _make_config(labels=["low", "high"])
+        core = np.linspace(0, 1, 90)
+        outliers = np.array([-100.0, -50.0, 50.0, 100.0, 200.0])
+        data = np.concatenate([core, outliers])
+        r = _make_reporter(data, data.copy(), config)
+        r.continuous_to_categorical()
+        # All values must be assigned to a valid bin index
+        assert set(r.truths).issubset({0, 1})
+        # Large positive outliers → bin 1 (high)
+        assert r.truths[-1] == 1
+        # Large negative outliers → bin 0 (low)
+        assert r.truths[len(core)] == 0
+
+    def test_default_labels_applied_when_missing(self):
+        """When no labels are set, defaults ['low','high'] are used → 2 bins."""
+        config = _make_config()  # no labels, no bins
+        data = np.linspace(0, 1, 50)
+        r = _make_reporter(data, data.copy(), config)
+        r.continuous_to_categorical()
+        assert set(r.truths).issubset({0, 1})

--- a/tests/test_plot_distributions.py
+++ b/tests/test_plot_distributions.py
@@ -1,0 +1,162 @@
+"""Tests for plot_distributions statistical result storage in plots.py."""
+
+import ast
+import configparser
+import os
+from unittest.mock import MagicMock, patch
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import nkululeko.glob_conf as glob_conf
+
+
+@pytest.fixture(autouse=True)
+def setup_glob_conf(tmp_path):
+    """Provide a minimal config and mock report for every test."""
+    config = configparser.ConfigParser()
+    config["EXP"] = {
+        "type": "classification",
+        "name": "testexp",
+        "root": str(tmp_path),
+    }
+    config["DATA"] = {"target": "emotion", "databases": "['emodb']"}
+    config["MODEL"] = {"type": "xgb"}
+    config["FEATS"] = {"type": "['os']"}
+    config["EXPL"] = {"value_counts": "[(['emotion', 'age'])]"}
+    config["PLOT"] = {"format": "png", "titles": "False"}
+    glob_conf.config = config
+    glob_conf.report = MagicMock()
+    yield
+    glob_conf.config = None
+
+
+def _make_df():
+    """Categorical label + one continuous and one categorical attribute."""
+    rng = np.random.default_rng(0)
+    n = 60
+    labels = pd.Categorical(["happy"] * 20 + ["sad"] * 20 + ["neutral"] * 20)
+    age = rng.normal(loc=30, scale=5, size=n)  # continuous
+    gender = pd.Categorical(["m"] * 30 + ["f"] * 30)  # categorical
+    df = pd.DataFrame({"class_label": labels, "age": age, "gender": gender})
+    df["class_label"] = df["class_label"].astype("category")
+    return df
+
+
+class TestPlotDistributionsStats:
+    """Statistical results are written for categorical-label vs continuous-attribute."""
+
+    def _make_plots(self, tmp_path):
+        from nkululeko.plots import Plots
+
+        fig_dir = os.path.join(str(tmp_path), "images")
+        res_dir = os.path.join(str(tmp_path), "results", "run_0")
+        os.makedirs(fig_dir, exist_ok=True)
+        os.makedirs(res_dir, exist_ok=True)
+
+        with patch(
+            "nkululeko.utils.util.Util.get_path",
+            side_effect=lambda p: fig_dir + "/" if p == "fig_dir" else res_dir + "/",
+        ):
+            plots = Plots()
+        return plots, res_dir
+
+    def test_result_file_created(self, tmp_path):
+        """A result file is created for a categorical-label vs continuous-attribute pair."""
+        plots, res_dir = self._make_plots(tmp_path)
+        df = _make_df()
+        glob_conf.config["EXPL"]["value_counts"] = "[['age']]"
+
+        fig_dir = os.path.join(str(tmp_path), "images")
+        res_dir_path = os.path.join(str(tmp_path), "results", "run_0")
+
+        with (
+            patch("nkululeko.utils.util.Util.get_path",
+                  side_effect=lambda p: fig_dir + "/" if p == "fig_dir" else res_dir_path + "/"),
+            patch("matplotlib.pyplot.savefig"),
+            patch("matplotlib.pyplot.close"),
+        ):
+            plots.plot_distributions(df)
+
+        files = os.listdir(res_dir_path)
+        assert any("value_counts_emotion_age" in f for f in files), f"Expected result file, got: {files}"
+
+    def test_result_file_contains_overall_and_pairwise(self, tmp_path):
+        """Result file has parseable 'overall:' and 'pairwise:' lines."""
+        plots, _ = self._make_plots(tmp_path)
+        df = _make_df()
+        glob_conf.config["EXPL"]["value_counts"] = "[['age']]"
+
+        fig_dir = os.path.join(str(tmp_path), "images")
+        res_dir_path = os.path.join(str(tmp_path), "results", "run_0")
+
+        with (
+            patch("nkululeko.utils.util.Util.get_path",
+                  side_effect=lambda p: fig_dir + "/" if p == "fig_dir" else res_dir_path + "/"),
+            patch("matplotlib.pyplot.savefig"),
+            patch("matplotlib.pyplot.close"),
+        ):
+            plots.plot_distributions(df)
+
+        res_file = os.path.join(res_dir_path, "value_counts_emotion_age.txt")
+        assert os.path.isfile(res_file)
+        with open(res_file) as f:
+            lines = f.read().splitlines()
+        overall_lines = [l for l in lines if l.startswith("overall:")]
+        pairwise_lines = [l for l in lines if l.startswith("pairwise:")]
+        assert overall_lines, "Expected at least one 'overall:' line"
+        assert pairwise_lines, "Expected at least one 'pairwise:' line"
+        # Lines must be parseable as Python dicts
+        parsed_overall = ast.literal_eval(overall_lines[0][len("overall: "):])
+        parsed_pairwise = ast.literal_eval(pairwise_lines[0][len("pairwise: "):])
+        assert isinstance(parsed_overall, dict)
+        assert isinstance(parsed_pairwise, dict)
+
+    def test_no_result_file_for_two_continuous(self, tmp_path):
+        """No result file is created when both columns are continuous (no categorical grouping)."""
+        plots, _ = self._make_plots(tmp_path)
+        rng = np.random.default_rng(1)
+        n = 30
+        df = pd.DataFrame({
+            "class_label": rng.normal(size=n),
+            "age": rng.normal(size=n),
+        })
+        glob_conf.config["EXPL"]["value_counts"] = "[['age']]"
+
+        fig_dir = os.path.join(str(tmp_path), "images")
+        res_dir_path = os.path.join(str(tmp_path), "results", "run_0")
+
+        with (
+            patch("nkululeko.utils.util.Util.get_path",
+                  side_effect=lambda p: fig_dir + "/" if p == "fig_dir" else res_dir_path + "/"),
+            patch("matplotlib.pyplot.savefig"),
+            patch("matplotlib.pyplot.close"),
+        ):
+            plots.plot_distributions(df)
+
+        files = os.listdir(res_dir_path)
+        assert not any("value_counts_" in f for f in files), f"Unexpected result file: {files}"
+
+    def test_result_file_deduplication(self, tmp_path):
+        """Running plot_distributions twice does not duplicate lines in result file."""
+        plots, _ = self._make_plots(tmp_path)
+        df = _make_df()
+        glob_conf.config["EXPL"]["value_counts"] = "[['age']]"
+
+        fig_dir = os.path.join(str(tmp_path), "images")
+        res_dir_path = os.path.join(str(tmp_path), "results", "run_0")
+
+        with (
+            patch("nkululeko.utils.util.Util.get_path",
+                  side_effect=lambda p: fig_dir + "/" if p == "fig_dir" else res_dir_path + "/"),
+            patch("matplotlib.pyplot.savefig"),
+            patch("matplotlib.pyplot.close"),
+        ):
+            plots.plot_distributions(df)
+            plots.plot_distributions(df)
+
+        res_file = os.path.join(res_dir_path, "value_counts_emotion_age.txt")
+        with open(res_file) as f:
+            lines = [l for l in f.read().splitlines() if l.startswith("overall:")]
+        assert len(lines) == 1, f"Expected 1 overall: line, got {len(lines)}"


### PR DESCRIPTION
For regression experiments, you now don't need to specify bins to compute confusion matrices, they will be computed automatically based on the labels, or if they are also not specified, according to binary binning based on the mean value