### PR TITLE
fix: eliminate eval() in feat_extract and resolve SonarQube duplicati…

### DIFF
--- a/nkululeko/feat_extract/feats_agender.py
+++ b/nkululeko/feat_extract/feats_agender.py
@@ -46,11 +46,7 @@ class AgenderSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if no_reuse or extract or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug(
                 "extracting agender model embeddings, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_agender_agender.py
+++ b/nkululeko/feat_extract/feats_agender_agender.py
@@ -48,12 +48,8 @@ class Agender_agenderSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
         sampling_rate = 16000
-        if no_reuse or extract or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug(
                 "extracting agender model age and gender, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_analyser.py
+++ b/nkululeko/feat_extract/feats_analyser.py
@@ -103,6 +103,13 @@ class FeatureAnalyser:
             pickle.dump(importance, f)
         return importance
 
+    def _maybe_plot_tree(self, model):
+        """Plot decision tree if configured."""
+        if self.util.config_val_bool("EXPL", "plot_tree", False):
+            model.fit(self.features, self.labels)
+            plots = Plots()
+            plots.plot_tree(model, self.features)
+
     def analyse_shap(self, model):
         """Shap analysis.
 
@@ -178,7 +185,7 @@ class FeatureAnalyser:
         model_name = "_".join(models)
         max_feat_num = int(self.util.config_val("EXPL", "max_feats", "10"))
         # https://scikit-learn.org/stable/modules/permutation_importance.html
-        permutation = eval(self.util.config_val("EXPL", "permutation", "False"))
+        permutation = self.util.config_val_bool("EXPL", "permutation", False)
         importance = None
         self.util.debug("analysing features...")
         result_importances = {}
@@ -240,20 +247,13 @@ class FeatureAnalyser:
                     result_importances[model_s] = self._get_importance(
                         model, permutation
                     )
-                    plot_tree = eval(self.util.config_val("EXPL", "plot_tree", "False"))
-                    if plot_tree:
-                        plots = Plots()
-                        plots.plot_tree(model, self.features)
+                    self._maybe_plot_tree(model)
                 elif model_s == "tree":
                     model = DecisionTreeClassifier(random_state=42)
                     result_importances[model_s] = self._get_importance(
                         model, permutation
                     )
-                    plot_tree = eval(self.util.config_val("EXPL", "plot_tree", "False"))
-                    if plot_tree:
-                        model.fit(self.features, self.labels)
-                        plots = Plots()
-                        plots.plot_tree(model, self.features)
+                    self._maybe_plot_tree(model)
                 elif model_s == "xgb":
                     from xgboost import XGBClassifier
 

--- a/nkululeko/feat_extract/feats_ast.py
+++ b/nkululeko/feat_extract/feats_ast.py
@@ -36,9 +36,8 @@ class Ast(Featureset):
         """Extract the features or load them from disk if present."""
         store = self.util.get_path("store")
         storage = f"{store}{self.name}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("extracting wavlm embeddings, this might take a while...")

--- a/nkululeko/feat_extract/feats_auddim.py
+++ b/nkululeko/feat_extract/feats_auddim.py
@@ -41,11 +41,7 @@ class AuddimSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if no_reuse or extract or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug(
                 "extracting audmodel dimensions, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_audmodel.py
+++ b/nkululeko/feat_extract/feats_audmodel.py
@@ -119,11 +119,7 @@ class AudmodelSet(Featureset):
             storage = f"{store}{self.name}.{store_format}"
         else:
             storage = f"{store}{self.name}_l{self.hidden_layer}.{store_format}"
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if no_reuse or extract or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug(
                 "extracting audmodel embeddings, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_audwav2vec2.py
+++ b/nkululeko/feat_extract/feats_audwav2vec2.py
@@ -56,11 +56,7 @@ class Audwav2vec2Set(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if no_reuse or extract or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug(
                 "extracting audwav2vec2 embeddings, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_bert.py
+++ b/nkululeko/feat_extract/feats_bert.py
@@ -55,10 +55,8 @@ class Bert(Featureset):
         """Extract the features or load them from disk if present."""
         store = self.util.get_path("store")
         storage = os.path.join(store, f"{self.name}.pkl")
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
         text_column = self.util.config_val("FEATS", "bert.text_column", "text")
-        if extract or no_reuse or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug(

--- a/nkululeko/feat_extract/feats_clap.py
+++ b/nkululeko/feat_extract/feats_clap.py
@@ -31,9 +31,8 @@ class ClapSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("extracting clap embeddings, this might take a while...")

--- a/nkululeko/feat_extract/feats_hubert.py
+++ b/nkululeko/feat_extract/feats_hubert.py
@@ -60,9 +60,8 @@ class Hubert(Featureset):
             storage = f"{store}{self.name}.pkl"
         else:
             storage = f"{store}{self.name}_l{str(self.hidden_layer)}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("extracting Hubert embeddings, this might take a while...")

--- a/nkululeko/feat_extract/feats_import.py
+++ b/nkululeko/feat_extract/feats_import.py
@@ -19,8 +19,8 @@ class ImportSet(Featureset):
         """Import the features."""
         self.util.debug(f"importing features for {self.name}")
         # import_files_append: set this to True if the multiple tables should be combined row-wise, else they are combined column-wise
-        import_files_append = eval(
-            self.util.config_val("FEATS", "import_files_append", "True")
+        import_files_append = self.util.config_val_bool(
+            "FEATS", "import_files_append", True
         )
         try:
             feat_import_files = self.util.config_val("FEATS", "import_file", False)

--- a/nkululeko/feat_extract/feats_mld.py
+++ b/nkululeko/feat_extract/feats_mld.py
@@ -32,14 +32,18 @@ class MLD_set(Featureset):
         import audmld
 
         mld_class_name = self.util.config_val("FEATS", "mld.df", "Mld")
-        mld_classes = {"Mld": audmld.Mld, "MldSust": audmld.MldSust, "MldStruct": audmld.MldStruct}
+        mld_classes = {
+            "Mld": audmld.Mld,
+            "MldSust": audmld.MldSust,
+            "MldStruct": audmld.MldStruct,
+        }
         if mld_class_name not in mld_classes:
             self.util.error(
                 f"FEATS.mld.df must be one of {list(mld_classes.keys())}, got '{mld_class_name}'"
             )
         self.util.debug(f"using MLD class: {mld_class_name}")
         cache_root = f"{storage}_{mld_class_name}"
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
+        no_reuse = self.util.config_val_bool("FEATS", "no_reuse", False)
         if no_reuse and os.path.exists(cache_root):
             os.remove(cache_root)
         if not os.path.isfile(cache_root):

--- a/nkululeko/feat_extract/feats_mos.py
+++ b/nkululeko/feat_extract/feats_mos.py
@@ -49,9 +49,8 @@ class MosSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("predicting MOS, this might take a while...")

--- a/nkululeko/feat_extract/feats_opensmile.py
+++ b/nkululeko/feat_extract/feats_opensmile.py
@@ -61,8 +61,8 @@ class Opensmileset(Featureset):
             )
 
         try:
-            self.feature_set = eval(f"opensmile.FeatureSet.{self.featset}")
-        except (AttributeError, SyntaxError) as e:
+            self.feature_set = getattr(opensmile.FeatureSet, self.featset)
+        except AttributeError as e:
             self.util.error(f"Invalid feature set: {self.featset}. Error: {str(e)}")
             raise ValueError(f"Invalid feature set: {self.featset}")
 
@@ -83,8 +83,8 @@ class Opensmileset(Featureset):
             )
 
         try:
-            self.feature_level = eval(f"opensmile.FeatureLevel.{self.featlevel}")
-        except (AttributeError, SyntaxError) as e:
+            self.feature_level = getattr(opensmile.FeatureLevel, self.featlevel)
+        except AttributeError as e:
             self.util.error(f"Invalid feature level: {self.featlevel}. Error: {str(e)}")
             raise ValueError(f"Invalid feature level: {self.featlevel}")
         self.print_feats = (
@@ -107,13 +107,7 @@ class Opensmileset(Featureset):
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
 
-        # Check if we need to extract features or use existing ones
-        extract = eval(
-            self.util.config_val("FEATS", "needs_feature_extraction", "False")
-        )
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-
-        if extract or not os.path.isfile(storage) or no_reuse:
+        if self._needs_extraction(storage):
             self.util.debug(
                 f"Extracting OpenSMILE {self.featset} features, this might take a while..."
             )

--- a/nkululeko/feat_extract/feats_oxbow.py
+++ b/nkululeko/feat_extract/feats_oxbow.py
@@ -20,12 +20,14 @@ class Openxbow(Featureset):
     def extract(self):
         """Extract the features or load them from disk if present."""
         self.featset = self.util.config_val("FEATS", "set", "eGeMAPSv02")
-        self.feature_set = eval(f"opensmile.FeatureSet.{self.featset}")
+        try:
+            self.feature_set = getattr(opensmile.FeatureSet, self.featset)
+        except AttributeError:
+            self.util.error(f"Invalid feature set: {self.featset}")
+            raise ValueError(f"Invalid feature set: {self.featset}")
         store = self.util.get_path("store")
         storage = f"{store}{self.name}_{self.featset}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             # extract smile features first
             self.util.debug("extracting openSmile features, this might take a while...")
             smile = opensmile.Smile(

--- a/nkululeko/feat_extract/feats_praat.py
+++ b/nkululeko/feat_extract/feats_praat.py
@@ -28,9 +28,8 @@ class PraatSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             self.util.debug("extracting Praat features, this might take a while...")
             self.df = feats_praat_core.compute_features(self.data_df.index)
             self.df = self.df.set_index(self.data_df.index)

--- a/nkululeko/feat_extract/feats_snr.py
+++ b/nkululeko/feat_extract/feats_snr.py
@@ -28,9 +28,8 @@ class SnrSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             self.util.debug("estimating SNR, this might take a while...")
             snr_series = pd.Series(index=self.data_df.index, dtype=object)
             for idx, (file, start, end) in enumerate(

--- a/nkululeko/feat_extract/feats_spectra.py
+++ b/nkululeko/feat_extract/feats_spectra.py
@@ -36,9 +36,8 @@ class Spectraloader(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             self.util.debug("extracting mel spectra, this might take a while...")
             image_store = audeer.mkdir(f"{store}{self.name}")
             images = []

--- a/nkululeko/feat_extract/feats_spkrec.py
+++ b/nkululeko/feat_extract/feats_spkrec.py
@@ -49,9 +49,8 @@ class Spkrec(Featureset):
         """Extract the features or load them from disk if present."""
         store = self.util.get_path("store")
         storage = f"{store}{self.name}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.classifier_initialized:
                 self.init_model()
             self.util.debug("extracting Spkrec embeddings, this might take a while...")

--- a/nkululeko/feat_extract/feats_sptk.py
+++ b/nkululeko/feat_extract/feats_sptk.py
@@ -6,6 +6,7 @@ pip install diffsptk
 
 """
 
+import ast
 import os
 
 import numpy as np
@@ -54,16 +55,14 @@ class SptkSet(Featureset):
             "FEATS", "sptk.features", "['stft', 'fbank']"
         )
         if isinstance(self.features_requested, str):
-            self.features_requested = eval(self.features_requested)
+            self.features_requested = ast.literal_eval(self.features_requested)
 
     def extract(self):
         """Extract the features or load them from disk if present."""
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+        if self._needs_extraction(storage):
             self.util.debug("extracting SPTK, this might take a while...")
 
             # Use core module for feature extraction

--- a/nkululeko/feat_extract/feats_squim.py
+++ b/nkululeko/feat_extract/feats_squim.py
@@ -52,9 +52,8 @@ class SquimSet(Featureset):
         store = self.util.get_path("store")
         store_format = self.util.config_val("FEATS", "store_format", "pkl")
         storage = f"{store}{self.name}.{store_format}"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("predicting SQUIM, this might take a while...")

--- a/nkululeko/feat_extract/feats_trill.py
+++ b/nkululeko/feat_extract/feats_trill.py
@@ -48,9 +48,8 @@ class TRILLset(Featureset):
     def extract(self):
         store = self.util.get_path("store")
         storage = f"{store}{self.name}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             self.util.debug("extracting TRILL embeddings, this might take a while...")
             if self.model is None:
                 self._load_model()

--- a/nkululeko/feat_extract/feats_wav2vec2.py
+++ b/nkululeko/feat_extract/feats_wav2vec2.py
@@ -64,9 +64,8 @@ class Wav2vec2(Featureset):
             storage = f"{store}{self.name}.pkl"
         else:
             storage = f"{store}{self.name}_l{str(self.hidden_layer)}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug(

--- a/nkululeko/feat_extract/feats_wavlm.py
+++ b/nkululeko/feat_extract/feats_wavlm.py
@@ -66,9 +66,8 @@ class Wavlm(Featureset):
             storage = f"{store}{self.name}.pkl"
         else:
             storage = f"{store}{self.name}_l{str(self.hidden_layer)}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("extracting wavlm embeddings, this might take a while...")

--- a/nkululeko/feat_extract/feats_whisper.py
+++ b/nkululeko/feat_extract/feats_whisper.py
@@ -37,9 +37,8 @@ class Whisper(Featureset):
         """Extract the features or load them from disk if present."""
         store = self.util.get_path("store")
         storage = f"{store}{self.name}.pkl"
-        extract = self.util.config_val("FEATS", "needs_feature_extraction", False)
-        no_reuse = eval(self.util.config_val("FEATS", "no_reuse", "False"))
-        if extract or no_reuse or not os.path.isfile(storage):
+
+        if self._needs_extraction(storage):
             if not self.model_initialized:
                 self.init_model()
             self.util.debug("extracting whisper embeddings, this might take a while...")

--- a/nkululeko/feat_extract/featureset.py
+++ b/nkululeko/feat_extract/featureset.py
@@ -27,6 +27,21 @@ class Featureset:
         self.feats_type = feats_type
         self.n_jobs = int(self.util.config_val("MODEL", "n_jobs", "8"))
 
+    def _needs_extraction(self, storage):
+        """Check whether features need to be (re-)extracted.
+
+        Args:
+            storage: Path to the stored features file.
+
+        Returns:
+            bool: True if extraction is needed.
+        """
+        import os
+
+        extract = self.util.config_val_bool("FEATS", "needs_feature_extraction", False)
+        no_reuse = self.util.config_val_bool("FEATS", "no_reuse", False)
+        return no_reuse or extract or not os.path.isfile(storage)
+
     def extract(self):
         pass
 

--- a/nkululeko/models/model_adm.py
+++ b/nkululeko/models/model_adm.py
@@ -352,7 +352,9 @@ class ADMModel(Model):
         with torch.no_grad():
             for index, (features, labels) in enumerate(loader):
                 start_index = index * loader.batch_size
-                end_index = start_index + len(labels)  # use actual batch size (last batch may be smaller)
+                end_index = start_index + len(
+                    labels
+                )  # use actual batch size (last batch may be smaller)
 
                 # Convert features to float32
                 features = features.float()
@@ -572,9 +574,7 @@ class ADMModel(Model):
         ).to(self.device)
 
         try:
-            self.model.load_state_dict(
-                torch.load(self.store_path, weights_only=True)
-            )
+            self.model.load_state_dict(torch.load(self.store_path, weights_only=True))
         except FileNotFoundError:
             self.util.error(f"model file not found: {self.store_path}")
         self.model.eval()

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -317,6 +317,20 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
     def reset_logged_configs(cls):
         cls.logged_configs.clear()
 
+    def config_val_bool(self, section, key, default=False):
+        """Get a boolean configuration value safely without using eval().
+
+        Args:
+            section: The config section name.
+            key: The config key name.
+            default: The default value (bool or string).
+
+        Returns:
+            bool: The boolean value of the config entry.
+        """
+        val = self.config_val(section, key, str(default))
+        return str(val).strip().lower() in ("true", "1", "yes")
+
     def config_val_list(self, section, key, default):
         try:
             return ast.literal_eval(self.config[section][key])

--- a/tests/feat_extract/test_feats_bert.py
+++ b/tests/feat_extract/test_feats_bert.py
@@ -129,28 +129,21 @@ def test_extract_creates_and_loads_pickle(tmp_path, bert_instance):
             assert bert_instance.df.shape[1] == 768  # BERT embedding size
 
         # Now test loading from cache
-        def config_val_mock_cache(section, key, default=None):
-            if key == "needs_feature_extraction":
-                return False  # Use cache
-            elif key == "no_reuse":
-                return "False"
-            elif key == "bert.model":
-                return "bert-base-uncased"
-            else:
-                return default
+        # Mock _needs_extraction to return False (cache hit)
+        with patch.object(type(bert_instance), "_needs_extraction", return_value=False):
+            with patch("os.path.isfile", return_value=True):
+                with patch("pandas.read_pickle") as mock_read_pickle:
+                    cached_df = pd.DataFrame(
+                        {"feat_0": [0.1, 0.2], "feat_1": [0.3, 0.4]}
+                    )
+                    mock_read_pickle.return_value = cached_df
 
-        with patch("os.path.isfile", return_value=True):
-            with patch("pandas.read_pickle") as mock_read_pickle:
-                cached_df = pd.DataFrame({"feat_0": [0.1, 0.2], "feat_1": [0.3, 0.4]})
-                mock_read_pickle.return_value = cached_df
+                    bert_instance2 = bert_instance
+                    bert_instance2.extract()
 
-                bert_instance2 = bert_instance
-                bert_instance2.util.config_val.side_effect = config_val_mock_cache
-                bert_instance2.extract()
-
-                # Verify that pd.read_pickle was called
-                mock_read_pickle.assert_called_once()
-                assert isinstance(bert_instance2.df, pd.DataFrame)
+                    # Verify that pd.read_pickle was called
+                    mock_read_pickle.assert_called_once()
+                    assert isinstance(bert_instance2.df, pd.DataFrame)
 
 
 def test_get_embeddings_returns_numpy_array(bert_instance):

--- a/tests/feat_extract/test_feats_sptk.py
+++ b/tests/feat_extract/test_feats_sptk.py
@@ -77,15 +77,9 @@ def test_extract_reuses_cached_features(sptk_set, mock_util):
     """Test that extract reuses cached features when available."""
     cached_df = pd.DataFrame({"stft_mean": [0.5], "fbank_0_mean": [0.3]})
     mock_util.get_store = Mock(return_value=cached_df)
-    mock_util.config_val = Mock(
-        side_effect=lambda section, key, default: {
-            ("FEATS", "store_format"): "pkl",
-            ("FEATS", "needs_feature_extraction"): False,
-            ("FEATS", "no_reuse"): "False",
-        }.get((section, key), default)
-    )
 
-    with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=True):
+    # Mock _needs_extraction to return False (cache hit)
+    with patch.object(type(sptk_set), "_needs_extraction", return_value=False):
         result = sptk_set.extract()
 
         assert result is not None
@@ -248,15 +242,9 @@ def test_extract_error_on_cached_nan_values(sptk_set, mock_util):
     """Test that extract raises error when cached data contains NaN."""
     cached_df = pd.DataFrame({"stft_mean": [0.5, np.nan], "fbank_0_mean": [0.3, 0.4]})
     mock_util.get_store = Mock(return_value=cached_df)
-    mock_util.config_val = Mock(
-        side_effect=lambda section, key, default: {
-            ("FEATS", "store_format"): "pkl",
-            ("FEATS", "needs_feature_extraction"): False,
-            ("FEATS", "no_reuse"): "False",
-        }.get((section, key), default)
-    )
 
-    with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=True):
+    # Mock _needs_extraction to return False (cache hit)
+    with patch.object(type(sptk_set), "_needs_extraction", return_value=False):
         sptk_set.extract()
 
         # Verify error was called due to NaN values

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -82,6 +82,42 @@ class TestConfigVal:
 
 
 # ---------------------------------------------------------------------------
+# config_val_bool
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValBool:
+    @pytest.mark.parametrize("value", ["True", "TRUE", "1", "yes", "  yes  "])
+    def test_truthy_string_values(self, value):
+        glob_conf.config["FEATS"]["no_reuse"] = value
+        u = Util("test")
+        assert u.config_val_bool("FEATS", "no_reuse", False) is True
+
+    @pytest.mark.parametrize("value", ["False", "  False  "])
+    def test_falsy_string_values(self, value):
+        glob_conf.config["FEATS"]["no_reuse"] = value
+        u = Util("test")
+        assert u.config_val_bool("FEATS", "no_reuse", True) is False
+
+    def test_returns_default_for_missing_key(self):
+        u = Util("test")
+        assert u.config_val_bool("FEATS", "nonexistent", False) is False
+        assert u.config_val_bool("FEATS", "nonexistent", True) is True
+
+    def test_returns_existing_bool_value(self):
+        # ConfigParser stores strings only; verify bool defaults convert correctly
+        u = Util("test", has_config=False)
+        assert u.config_val_bool("FEATS", "no_reuse", True) is True
+        assert u.config_val_bool("FEATS", "no_reuse", False) is False
+
+    def test_rejects_arbitrary_code(self):
+        glob_conf.config["FEATS"]["no_reuse"] = "__import__('os').system('echo hacked')"
+        u = Util("test")
+        # Should safely return False, not execute code
+        assert u.config_val_bool("FEATS", "no_reuse", False) is False
+
+
+# ---------------------------------------------------------------------------
 # set_config_val
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Solving issues here: https://github.com/bagustris/nkululeko/issues/34

* Initial plan

* fix: replace unsafe eval() with getattr(), config_val_bool(), and ast.literal_eval()

Replace all unsafe eval() calls on user-supplied config values in feat_extract/ with safe alternatives:
- Boolean configs: new Util.config_val_bool() method
- Enum attribute access: getattr() with validation
- List parsing: ast.literal_eval()

This eliminates arbitrary code execution risk from untrusted config files.

* fix: add error handling for getattr in feats_oxbow.py

* fix: address SonarQube duplication and reviewer suggestions in tests

- Remove redundant test_handles_bool_default (duplicate of test_returns_default_for_missing_key)
- Add test_trims_whitespace_in_boolean_values (sourcery suggestion)
- Add test_returns_existing_bool_value testing bool-default path with no config
- Remove unreachable isinstance(val, bool) dead code from config_val_bool
- Resolve merge conflict in feats_audmodel.py: keep main's hidden_layer storage path logic while applying config_val_bool instead of eval()

* fix: remove redundant SyntaxError from getattr exception handling in feats_opensmile.py

* fix: extract _needs_extraction() helper to eliminate duplicated config_val_bool blocks

Move repeated extract/no_reuse config lookup and file-existence check into Featureset._needs_extraction() base class method. This reduces the 3-line duplicated block (extract=..., no_reuse=..., if extract or no_reuse or not os.path.isfile) across 23 feature extractors to a single method call, fixing the SonarQube quality gate duplication threshold (was 11%, required ≤3%).

Also extract _maybe_plot_tree() in feats_analyser.py to deduplicate the repeated plot_tree config check + plot call.

* fix: use parametrize to eliminate repeated test patterns and resolve SonarQube duplication

* fix: update tests and restore model_adm regressions from PR

Tests now mock _needs_extraction directly instead of config_val.

Restored _encode_labels, get_loader TensorDataset, store/load metadata, get_probas safeguard.

---------