### PR TITLE
fix: silent NaN to zero fill

### DIFF
--- a/nkululeko/feat_extract/feats_analyser.py
+++ b/nkululeko/feat_extract/feats_analyser.py
@@ -3,16 +3,13 @@ import ast
 import os
 import pickle
 
+import audeer
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from sklearn.inspection import permutation_importance
-from sklearn.linear_model import LinearRegression
-from sklearn.linear_model import LogisticRegression
-from sklearn.tree import DecisionTreeClassifier
-from sklearn.tree import DecisionTreeRegressor
-
-import audeer
+from sklearn.linear_model import LinearRegression, LogisticRegression
+from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.plots import Plots
@@ -33,17 +30,7 @@ class FeatureAnalyser:
         # Create a copy of df_features to avoid modifying the original DataFrame
         df_features = df_features.copy()
         # check for NaN values in the features
-        for col in df_features.columns:
-            if df_features[col].isnull().values.any():
-                self.util.debug(
-                    f"{col} includes {df_features[col].isnull().sum()} nan,"
-                    " inserting mean values"
-                )
-                mean_val = df_features[col].mean()
-                if not np.isnan(mean_val):
-                    df_features[col] = df_features[col].fillna(mean_val)
-                else:
-                    df_features[col] = df_features[col].fillna(0)
+        df_features = self.util.handle_nan(df_features, context="feature analysis")
 
         self.features = df_features
         self.label = label

--- a/nkululeko/feat_extract/feats_cqcc.py
+++ b/nkululeko/feat_extract/feats_cqcc.py
@@ -131,7 +131,7 @@ class CqccSet(Featureset):
                     f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
                 )
 
-    def extract_sample(self, signal, sr):
+    def extract_sample(self, signal, _sr):
         if not self.extractor.available:
             self.extractor.warn_unavailable()
             return pd.DataFrame([{}]).to_numpy()

--- a/nkululeko/feat_extract/feats_import.py
+++ b/nkululeko/feat_extract/feats_import.py
@@ -40,11 +40,7 @@ class ImportSet(Featureset):
             if not os.path.isfile(feat_import_file):
                 self.util.error(f"no import file: {feat_import_file}")
             df = audformat.utils.read_csv(feat_import_file)
-            if df.isnull().values.any():
-                self.util.warn(
-                    f"imported features contain {df.isna().sum()} NAN, filling with zero."
-                )
-                df = df.fillna(0)
+            df = self.util.handle_nan(df, context="imported features")
             df = self.util.make_segmented_index(df)
             df = df[df.index.isin(self.data_df.index)]
             if import_files_append:

--- a/nkululeko/feat_extract/feats_lfcc.py
+++ b/nkululeko/feat_extract/feats_lfcc.py
@@ -141,7 +141,7 @@ class LfccSet(Featureset):
                     f"got nan: {self.df.shape} {self.df.isnull().sum().sum()}"
                 )
 
-    def extract_sample(self, signal, sr):
+    def extract_sample(self, signal, _sr):
         if not self.extractor.available:
             self.extractor.warn_unavailable()
             return pd.DataFrame([{}]).to_numpy()

--- a/nkululeko/feat_extract/feats_praat.py
+++ b/nkululeko/feat_extract/feats_praat.py
@@ -33,13 +33,7 @@ class PraatSet(Featureset):
             self.util.debug("extracting Praat features, this might take a while...")
             self.df = feats_praat_core.compute_features(self.data_df.index)
             self.df = self.df.set_index(self.data_df.index)
-            for i, col in enumerate(self.df.columns):
-                if self.df[col].isnull().values.any():
-                    self.util.debug(
-                        f"{col} includes {self.df[col].isnull().sum()} nan,"
-                        " inserting mean values"
-                    )
-                    self.df[col] = self.df[col].fillna(self.df[col].mean())
+            self.df = self.util.handle_nan(self.df, context="praat features")
 
             self.util.write_store(self.df, storage, store_format)
             try:
@@ -63,17 +57,7 @@ class PraatSet(Featureset):
         index = audformat.utils.to_segmented_index(df.index, allow_nat=False)
         df = feats_praat_core.compute_features(index)
         df.set_index(index)
-        for i, col in enumerate(df.columns):
-            if df[col].isnull().values.any():
-                self.util.debug(
-                    f"{col} includes {df[col].isnull().sum()} nan,"
-                    " inserting mean values"
-                )
-                mean_val = df[col].mean()
-                if not np.isnan(mean_val):
-                    df[col] = df[col].fillna(mean_val)
-                else:
-                    df[col] = df[col].fillna(0)
+        df = self.util.handle_nan(df, context="praat features")
         df = df.astype(float)
         feats = df.to_numpy()
         return feats

--- a/nkululeko/feat_extract/feats_praat_core.py
+++ b/nkululeko/feat_extract/feats_praat_core.py
@@ -8,15 +8,16 @@ taken June 23rd 2022.
 #!/usr/bin/env python3
 import math
 import statistics
+import warnings
 
 import audiofile
 import numpy as np
 import pandas as pd
 import parselmouth
 from parselmouth.praat import call
-from scipy.stats.mstats import zscore
-from scipy.stats import lognorm
 from scipy import stats
+from scipy.stats import lognorm
+from scipy.stats.mstats import zscore
 from sklearn.decomposition import PCA
 from tqdm import tqdm
 
@@ -376,7 +377,11 @@ def run_pca(df):
 
     # x = StandardScaler().fit_transform(x)
     if np.any(np.isnan(x[0])):
-        print(f"Warning: {np.count_nonzero(np.isnan(x))} Nans in x, replacing with 0")
+        nan_count = np.count_nonzero(np.isnan(x))
+        nan_pct = 100 * nan_count / x.size
+        warnings.warn(
+            f"PCA input: {nan_count} NaN values ({nan_pct:.1f}% of data), replacing with 0"
+        )
         x[np.isnan(x)] = 0
     # if np.any(np.isfinite(x[0])):
     #     print(f"Warning: {np.count_nonzero(np.isfinite(x))} finite in x")

--- a/nkululeko/feat_extract/feats_sptk_core.py
+++ b/nkululeko/feat_extract/feats_sptk_core.py
@@ -353,7 +353,7 @@ def compute_features(
         try:
             if isinstance(row_index, tuple) and len(row_index) == 3:
                 file, start, end = row_index
-                signal, sampling_rate = _read_audio(
+                signal, _ = _read_audio(
                     file,
                     offset=start.total_seconds(),
                     duration=(end - start).total_seconds(),
@@ -361,7 +361,7 @@ def compute_features(
             else:
                 # Single file path - read entire file
                 file = row_index if isinstance(row_index, str) else str(row_index)
-                signal, sampling_rate = _read_audio(file)
+                signal, _ = _read_audio(file)
 
             # Convert to tensor
             signal_tensor = torch.tensor(signal[0], device=device).float()

--- a/nkululeko/models/model.py
+++ b/nkululeko/models/model.py
@@ -3,15 +3,12 @@ import ast
 import pickle
 import random
 
-from joblib import parallel_backend
+import audeer
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import GridSearchCV
-from sklearn.model_selection import LeaveOneGroupOut
-from sklearn.model_selection import StratifiedKFold
 import sklearn.utils
-
-import audeer
+from joblib import parallel_backend
+from sklearn.model_selection import GridSearchCV, LeaveOneGroupOut, StratifiedKFold
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.reporting.reporter import Reporter
@@ -260,14 +257,7 @@ class Model:
             self._x_fold_cross()
             return
 
-        # check for NANs in the features
-        # set up the data_loaders
-        if self.feats_train.isna().to_numpy().any():
-            self.util.debug(
-                "Model, train: replacing"
-                f" {self.feats_train.isna().sum().sum()} NANs with 0"
-            )
-            self.feats_train = self.feats_train.fillna(0)
+        self.feats_train = self._handle_model_nan(self.feats_train, "Model, train")
         # remove labels from features
         feats = self.feats_train.to_numpy()
         # compute class weights
@@ -344,12 +334,7 @@ class Model:
         return predictions, probas
 
     def predict(self):
-        if self.feats_test.isna().to_numpy().any():
-            self.util.debug(
-                "Model, test: replacing"
-                f" {self.feats_test.isna().sum().sum()} NANs with 0"
-            )
-            self.feats_test = self.feats_test.fillna(0)
+        self.feats_test = self._handle_model_nan(self.feats_test, "Model, test")
         if self.logo or self.xfoldx:
             report = Reporter(
                 self.truths.astype(float), self.preds, self.run, self.epoch
@@ -367,6 +352,15 @@ class Model:
         )
         report.print_probabilities()
         return report
+
+    def _handle_model_nan(self, feats, context):
+        """Handle feature NaNs without changing row alignment with labels."""
+        return self.util.handle_nan(
+            feats,
+            context=context,
+            strategy=self.util.config_val("MODEL", "nan_strategy", "zero"),
+            allow_drop=False,
+        )
 
     def get_type(self):
         return "generic"

--- a/nkululeko/models/model_adm.py
+++ b/nkululeko/models/model_adm.py
@@ -200,17 +200,8 @@ class ADMModel(Model):
         )
         self.threshold = float(self.util.config_val("MODEL", "threshold", "0.5"))
 
-        # Handle NaN values
-        if feats_train.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, train: replacing {feats_train.isna().sum().sum()} NANs with 0"
-            )
-            feats_train = feats_train.fillna(0)
-        if feats_test.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, test: replacing {feats_test.isna().sum().sum()} NANs with 0"
-            )
-            feats_test = feats_test.fillna(0)
+        feats_train = self._handle_model_nan(feats_train, "Model, train")
+        feats_test = self._handle_model_nan(feats_test, "Model, test")
 
         # Set up data loaders
         self.trainloader = self.get_loader(feats_train, df_train, True)
@@ -352,40 +343,13 @@ class ADMModel(Model):
         with torch.no_grad():
             for index, (features, labels) in enumerate(loader):
                 start_index = index * loader.batch_size
-                end_index = start_index + len(
-                    labels
-                )  # use actual batch size (last batch may be smaller)
-
-                # Convert features to float32
-                features = features.float()
-
-                # Split features
-                ssl_feats, spec_feats, phase_feats, extra_feats = (
-                    self._split_feature_streams(features)
+                end_index = start_index + len(labels)
+                batch_logits, batch_targets, loss = self._evaluate_batch(
+                    model, features, labels, device
                 )
-
-                # Forward pass
-                batch_logits = model(
-                    ssl_feats.to(device),
-                    spec_feats.to(device),
-                    phase_feats.to(device),
-                    {k: v.to(device) for k, v in extra_feats.items()},
-                )
-
-                # Clean non-finite logits before storing; move to CPU to match preallocated tensors
-                batch_logits = (
-                    torch.nan_to_num(batch_logits, nan=0.0, posinf=10.0, neginf=-10.0)
-                    .detach()
-                    .cpu()
-                )
-
                 logits[start_index:end_index] = batch_logits
-                targets[start_index:end_index] = labels.detach().cpu()
-
-                loss = self.criterion(
-                    batch_logits.to(device), labels.float().to(device)
-                )
-                losses.append(loss.item())
+                targets[start_index:end_index] = batch_targets
+                losses.append(loss)
 
         self.loss_eval = (np.asarray(losses)).mean()
 
@@ -395,6 +359,25 @@ class ADMModel(Model):
         uar = recall_score(targets.numpy(), predictions.numpy(), average="macro")
 
         return uar, targets, predictions, logits
+
+    def _evaluate_batch(self, model, features, labels, device):
+        """Run one evaluation batch and return CPU tensors plus loss."""
+        ssl_feats, spec_feats, phase_feats, extra_feats = self._split_feature_streams(
+            features.float()
+        )
+        batch_logits = model(
+            ssl_feats.to(device),
+            spec_feats.to(device),
+            phase_feats.to(device),
+            {key: value.to(device) for key, value in extra_feats.items()},
+        )
+        loss = self.criterion(batch_logits, labels.float().to(device)).item()
+        batch_logits = (
+            torch.nan_to_num(batch_logits, nan=0.0, posinf=10.0, neginf=-10.0)
+            .detach()
+            .cpu()
+        )
+        return batch_logits, labels.detach().cpu(), loss
 
     def get_probas(self, logits):
         """Convert logits to probability dataframe."""
@@ -469,9 +452,10 @@ class ADMModel(Model):
         except (TypeError, ValueError):
             pass
 
-        if glob_conf.label_encoder is not None:
+        label_encoder = getattr(glob_conf, "label_encoder", None)
+        if label_encoder is not None:
             try:
-                return glob_conf.label_encoder.transform(labels).astype(float)
+                return label_encoder.transform(labels).astype(float)
             except ValueError:
                 pass
 
@@ -489,13 +473,13 @@ class ADMModel(Model):
         """Set run and epoch ID with branch configuration in filename."""
         self.run = run
         self.epoch = epoch
-        dir = self.util.get_path("model_dir")
+        model_dir = self.util.get_path("model_dir")
 
         # Include branch configuration in model filename
         # e.g., "tsp" for time+spectral+phase, "ts" for time+spectral
         branch_suffix = "".join([b[0] for b in self.branches])
         name = f"{self.util.get_exp_name(only_train=True)}_{branch_suffix}_{self.run}_{self.epoch:03d}.model"
-        self.store_path = dir + name
+        self.store_path = model_dir + name
 
     def store(self):
         """Store the model weights and feature split metadata to disk."""
@@ -574,7 +558,9 @@ class ADMModel(Model):
         ).to(self.device)
 
         try:
-            self.model.load_state_dict(torch.load(self.store_path, weights_only=True))
+            self.model.load_state_dict(
+                torch.load(self.store_path, map_location=self.device, weights_only=True)
+            )
         except FileNotFoundError:
             self.util.error(f"model file not found: {self.store_path}")
         self.model.eval()

--- a/nkululeko/models/model_mlp.py
+++ b/nkululeko/models/model_mlp.py
@@ -4,8 +4,8 @@ from collections import OrderedDict
 
 import numpy as np
 import pandas as pd
-from sklearn.metrics import recall_score
 import torch
+from sklearn.metrics import recall_score
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model
@@ -80,16 +80,8 @@ class MLPModel(Model):
         self.batch_size = int(self.util.config_val("MODEL", "batch_size", 8))
         # number of parallel processes
         self.num_workers = self.n_jobs
-        if feats_train.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, train: replacing {feats_train.isna().sum().sum()} NANs with 0"
-            )
-            feats_train = feats_train.fillna(0)
-        if feats_test.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, test: replacing {feats_test.isna().sum().sum()} NANs with 0"
-            )
-            feats_test = feats_test.fillna(0)
+        feats_train = self._handle_model_nan(feats_train, "Model, train")
+        feats_test = self._handle_model_nan(feats_test, "Model, test")
         # set up the data_loaders
         self.trainloader = self.get_loader(feats_train, df_train, True)
         self.testloader = self.get_loader(feats_test, df_test, False)

--- a/nkululeko/models/model_mlp_regression.py
+++ b/nkululeko/models/model_mlp_regression.py
@@ -72,17 +72,9 @@ class MLP_Reg_model(Model):
         self.batch_size = int(self.util.config_val("MODEL", "batch_size", 8))
         # number of parallel processes
         self.num_workers = self.n_jobs
+        feats_train = self._handle_model_nan(feats_train, "Model, train")
+        feats_test = self._handle_model_nan(feats_test, "Model, test")
         # set up the data_loaders
-        if feats_train.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, train: replacing {feats_train.isna().sum().sum()} NANs with 0"
-            )
-            feats_train = feats_train.fillna(0)
-        if feats_test.isna().to_numpy().any():
-            self.util.debug(
-                f"Model, test: replacing {feats_test.isna().sum().sum()} NANs with 0"
-            )
-            feats_test = feats_test.fillna(0)
         self.trainloader = self.get_loader(feats_train, df_train, True)
         self.testloader = self.get_loader(feats_test, df_test, False)
 

--- a/nkululeko/models/model_xgb.py
+++ b/nkululeko/models/model_xgb.py
@@ -1,5 +1,9 @@
 # model_xgb.py
 
+import ast
+
+from sklearn.model_selection import train_test_split
+from sklearn.utils.class_weight import compute_sample_weight
 from xgboost import XGBClassifier
 
 from nkululeko.models.model import Model
@@ -46,13 +50,7 @@ class XGB_model(Model):
 
     def train(self):
         """Train the XGBoost model with optional early stopping."""
-        # Check if NANs in features and handle them
-        if self.feats_train.isna().to_numpy().any():
-            self.util.debug(
-                "Model, train: replacing"
-                f" {self.feats_train.isna().sum().sum()} NANs with 0"
-            )
-            self.feats_train = self.feats_train.fillna(0)
+        self.feats_train = self._handle_model_nan(self.feats_train, "Model, train")
 
         # then if leave one speaker group out validation is wanted
         if self.logo:
@@ -72,24 +70,16 @@ class XGB_model(Model):
         # Check if early stopping is configured
         if self.early_stopping_rounds:
             # Check if we're in split3 mode (train/dev/test) where validation data is available
-            import ast
-
             split3 = ast.literal_eval(
                 self.util.config_val("EXP", "traindevtest", "False")
             )
 
             if split3 and self.feats_test is not None and self.df_test is not None:
                 # In split3 mode, self.feats_test and self.df_test are actually the dev set
-                feats_dev = self.feats_test.to_numpy()
                 labels_dev = self.df_test[self.target]
 
-                # Handle NANs in dev features
-                if self.feats_test.isna().to_numpy().any():
-                    self.util.debug(
-                        "Model, dev: replacing"
-                        f" {self.feats_test.isna().sum().sum()} NANs with 0"
-                    )
-                    feats_dev = self.feats_test.fillna(0).to_numpy()
+                self.feats_test = self._handle_model_nan(self.feats_test, "Model, dev")
+                feats_dev = self.feats_test.to_numpy()
 
                 # Set up early stopping with validation data
                 eval_set = [(feats, labels), (feats_dev, labels_dev)]
@@ -104,8 +94,6 @@ class XGB_model(Model):
                 self.util.debug(f"  - validation set size: {feats_dev.shape[0]}")
             else:
                 # For train/test split only: use a portion of training data for validation
-                from sklearn.model_selection import train_test_split
-
                 # Get validation split ratio (default 0.2 = 20% of training data)
                 val_split = float(
                     self.util.config_val("MODEL", "validation_split", 0.2)
@@ -148,12 +136,8 @@ class XGB_model(Model):
         # Handle class weights if configured
         class_weight = self.util.config_val("MODEL", "class_weight", False)
         if class_weight:
-            import sklearn.utils.class_weight
-
             self.util.debug("using class weight")
-            classes_weights = sklearn.utils.class_weight.compute_sample_weight(
-                class_weight="balanced", y=labels
-            )
+            classes_weights = compute_sample_weight(class_weight="balanced", y=labels)
             fit_params["sample_weight"] = classes_weights
 
         # Train the model

--- a/nkululeko/reporting/reporter.py
+++ b/nkululeko/reporting/reporter.py
@@ -320,7 +320,7 @@ class Reporter:
         # if there are no bins, set them to border points for the labels and save them to the config to be used later
         try:
             bins = ast.literal_eval(glob_conf.config["DATA"]["bins"])
-        except (KeyError, ValueError) as e:
+        except (KeyError, ValueError):
             label_num = len(ast.literal_eval(glob_conf.config["DATA"]["labels"]))
             vmin, vmax = np.percentile(self.truths, [5, 95])
             inner_edges = np.linspace(vmin, vmax, label_num + 1)[1:-1]
@@ -464,8 +464,8 @@ class Reporter:
                 labels = [str(i) for i in range(n_bins)]
             label_map = dict(zip(range(len(labels)), labels))
             n = len(labels)
-            truths = [label_map[min(max(int(t), 0), n - 1)] for t in list(truths)]
-            preds = [label_map[min(max(int(p), 0), n - 1)] for p in list(preds)]
+            truths = [label_map[min(max(int(t), 0), n - 1)] for t in truths]
+            preds = [label_map[min(max(int(p), 0), n - 1)] for p in preds]
 
         if le is not None:
             label_dict = dict(zip(range(len(le.classes_)), le.classes_))

--- a/nkululeko/utils/stats.py
+++ b/nkululeko/utils/stats.py
@@ -1,5 +1,6 @@
-from itertools import combinations
 import math
+import warnings
+from itertools import combinations
 from typing import Tuple
 
 import numpy as np
@@ -18,7 +19,10 @@ def check_na(a):
     """
     if np.isnan(a).any():
         count = np.count_nonzero(np.isnan(a))
-        print(f"WARNING: got {count} Nans (of {len(a)}), setting to 0")
+        pct = 100 * count / a.size
+        warnings.warn(
+            f"Got {count} NaN values ({pct:.1f}% of {a.size} elements), setting to 0"
+        )
         a[np.isnan(a)] = 0
     return a
 

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -9,13 +9,17 @@ import sys
 
 from pathlib import Path
 
-import numpy as np
-
 import audeer
+import numpy as np
 
 from nkululeko.utils.dataframe import DataFrameMixin
 from nkululeko.utils.naming import NamingMixin
 from nkululeko.utils.storage import StorageMixin
+
+
+class _MessageOnlyFormatter(logging.Formatter):
+    def format(self, record):
+        return record.getMessage()
 
 
 class Util(NamingMixin, StorageMixin, DataFrameMixin):
@@ -38,7 +42,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         "uar",
         "mse",
     ]
-    keyvals = [        
+    keyvals = [
         "kind",
     ]
 
@@ -75,75 +79,86 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         # self.logged_configs = set()
 
     def setup_logging(self):
-        # Setup logging
         logger = logging.getLogger(__name__)
         # Always set DEBUG so messages reach all handlers regardless of whether
         # an ancestor logger (e.g. root logger in notebooks) already has handlers.
         logger.setLevel(logging.DEBUG)
+        formatter = _MessageOnlyFormatter()
+        self._ensure_console_handler(logger, formatter)
 
-        # Create a simple formatter that only shows the message
-        class SimpleFormatter(logging.Formatter):
-            def format(self, record):
-                return record.getMessage()
+        if self.config is not None:
+            self._setup_file_logging(logger, formatter)
 
+        self.logger = logger
+
+    @staticmethod
+    def _ensure_console_handler(logger, formatter):
         # Only add a console handler if this logger has none yet.
         # Use logger.handlers (direct handlers) rather than hasHandlers()
         # so the check is scoped to this logger only, not the full hierarchy.
         if not logger.handlers:
             console_handler = logging.StreamHandler()
-            console_handler.setFormatter(SimpleFormatter())
+            console_handler.setFormatter(formatter)
             logger.addHandler(console_handler)
 
-        # Add or replace file handler when config is available
-        if self.config is not None:
-            try:
-                root = self.config["EXP"]["root"]
-                name = self.config["EXP"]["name"]
-                log_dir = os.path.abspath(os.path.join(root, name, "log"))
-                audeer.mkdir(log_dir)
-                # Include seconds to avoid filename collisions between close-together runs
-                timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
-                log_file = os.path.join(log_dir, f"{name}_{timestamp}.log")
+    def _setup_file_logging(self, logger, formatter):
+        try:
+            root = self.config["EXP"]["root"]
+            name = self.config["EXP"]["name"]
+            log_dir, log_file, timestamp = self._build_log_path(root, name)
+            self._remove_stale_file_handlers(logger, log_dir)
 
-                # Collect stale file handlers (different experiment dir) then remove them
-                # to avoid mutating the handlers list during iteration.
-                stale = [
-                    h
-                    for h in logger.handlers
-                    if isinstance(h, logging.FileHandler)
-                    and os.path.dirname(h.baseFilename) != log_dir
-                ]
-                for handler in stale:
-                    handler.close()
-                    logger.removeHandler(handler)
+            if self._has_file_handler(logger):
+                return
 
-                if not any(isinstance(h, logging.FileHandler) for h in logger.handlers):
-                    file_handler = logging.FileHandler(log_file)
-                    file_handler.setFormatter(SimpleFormatter())
-                    logger.addHandler(file_handler)
+            file_handler = logging.FileHandler(log_file)
+            file_handler.setFormatter(formatter)
+            logger.addHandler(file_handler)
+            self._copy_config_snapshot(log_dir, name, timestamp)
+        except KeyError:
+            logger.debug("File logging skipped: EXP configuration (root/name) incomplete")
+        except OSError as e:
+            logger.debug(f"File logging skipped: could not create log file ({e})")
 
-                    # Save a timestamped config snapshot alongside the log file.
-                    # Reads --config from sys.argv so no entry-point changes are needed.
-                    # Preserves the original file's extension (format-independent).
-                    src = None
-                    if "--config" in sys.argv:
-                        idx = sys.argv.index("--config")
-                        if idx + 1 < len(sys.argv):
-                            src = sys.argv[idx + 1]
-                    if src and os.path.isfile(src):
-                        ext = os.path.splitext(src)[1]
-                        config_snapshot = os.path.join(
-                            log_dir, f"{name}_{timestamp}{ext}"
-                        )
-                        shutil.copy2(src, config_snapshot)
-            except KeyError:
-                logger.debug(
-                    "File logging skipped: EXP configuration (root/name) incomplete"
-                )
-            except OSError as e:
-                logger.debug(f"File logging skipped: could not create log file ({e})")
+    @staticmethod
+    def _build_log_path(root, name):
+        log_dir = os.path.abspath(os.path.join(root, name, "log"))
+        audeer.mkdir(log_dir)
+        timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+        return log_dir, os.path.join(log_dir, f"{name}_{timestamp}.log"), timestamp
 
-        self.logger = logger
+    @staticmethod
+    def _remove_stale_file_handlers(logger, log_dir):
+        stale = [
+            handler
+            for handler in logger.handlers
+            if isinstance(handler, logging.FileHandler)
+            and os.path.dirname(handler.baseFilename) != log_dir
+        ]
+        for handler in stale:
+            handler.close()
+            logger.removeHandler(handler)
+
+    @staticmethod
+    def _has_file_handler(logger):
+        return any(isinstance(handler, logging.FileHandler) for handler in logger.handlers)
+
+    @staticmethod
+    def _config_snapshot_source():
+        if "--config" not in sys.argv:
+            return None
+        idx = sys.argv.index("--config")
+        if idx + 1 >= len(sys.argv):
+            return None
+        return sys.argv[idx + 1]
+
+    def _copy_config_snapshot(self, log_dir, name, timestamp):
+        src = self._config_snapshot_source()
+        if not src or not os.path.isfile(src):
+            return
+        ext = os.path.splitext(src)[1]
+        config_snapshot = os.path.join(log_dir, f"{name}_{timestamp}{ext}")
+        shutil.copy2(src, config_snapshot)
 
     def get_path(self, entry):
         """This method allows the user to get the directory path for the given argument."""
@@ -264,6 +279,61 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
             self.logger.debug(f"DEBUG: {self.caller}: {message}")
         else:
             print(f"DEBUG: {message}", flush=True)
+
+    def handle_nan(self, df, context="features", strategy=None, allow_drop=True):
+        """Handle NaN values in a DataFrame with configurable strategy.
+
+        Args:
+            df: pandas DataFrame to check and fill NaN values in.
+            context: string describing where the NaN was found (for logging).
+            strategy: optional strategy override. If unset, FEATS.nan_strategy is used.
+            allow_drop: whether the drop strategy may remove rows.
+
+        Returns:
+            DataFrame with NaN values handled according to configured strategy.
+        """
+        if not df.isna().to_numpy().any():
+            return df
+
+        nan_count = df.isna().sum().sum()
+        nan_pct = 100 * nan_count / df.size
+        raw_strategy = (
+            strategy
+            if strategy is not None
+            else self.config_val("FEATS", "nan_strategy", "zero")
+        )
+        strategy = str(raw_strategy).strip().lower()
+        valid_strategies = {"zero", "mean", "median", "drop"}
+        if strategy not in valid_strategies:
+            self.warn(
+                f"{context}: unknown NaN strategy '{raw_strategy}', using strategy 'zero'"
+            )
+            strategy = "zero"
+        elif strategy == "drop" and not allow_drop:
+            self.warn(
+                f"{context}: NaN strategy 'drop' is not allowed because it can "
+                "misalign features and labels, using strategy 'zero'"
+            )
+            strategy = "zero"
+
+        self.warn(
+            f"{context}: replacing {nan_count} NaN values"
+            f" ({nan_pct:.1f}% of data) with strategy '{strategy}'"
+        )
+
+        if strategy == "mean":
+            # Second fillna(0) handles columns where all values are NaN (mean is NaN)
+            numeric_means = df.mean(numeric_only=True)
+            return df.fillna(numeric_means).fillna(0)
+        elif strategy == "median":
+            # Second fillna(0) handles columns where all values are NaN (median is NaN)
+            numeric_medians = df.median(numeric_only=True)
+            return df.fillna(numeric_medians).fillna(0)
+        elif strategy == "drop":
+            return df.dropna()
+        else:
+            # Default: zero
+            return df.fillna(0)
 
     def set_config_val(self, section, key, value):
         try:

--- a/tests/models/test_model_adm.py
+++ b/tests/models/test_model_adm.py
@@ -14,7 +14,6 @@ from nkululeko.models.model_adm_core import (
     DeepfakeADMModel,
 )
 
-
 # ============================================================
 # Tests for ADM Core Components
 # ============================================================
@@ -537,7 +536,7 @@ class TestADMModel:
         assert store_path.exists()
 
         # Load into new state dict
-        loaded_state = torch.load(str(store_path))
+        loaded_state = torch.load(str(store_path), weights_only=True)
         assert "time_adm.fc1.weight" in loaded_state
         assert "spec_adm.fc2.weight" in loaded_state
         assert "phase_adm.fc1.weight" in loaded_state

--- a/tests/test_bundle_infer.py
+++ b/tests/test_bundle_infer.py
@@ -185,7 +185,7 @@ class TestLoadBundle:
         # Create minimal bundle
         from sklearn.svm import SVC
 
-        model = SVC(probability=True)
+        model = SVC(C=1.0, kernel="rbf", gamma="scale", probability=True, random_state=0)
         model.fit([[1, 2], [3, 4]], [0, 1])
 
         manifest = {
@@ -289,7 +289,7 @@ class TestPredictFromBundle:
         # Train a tiny model
         X_train = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
         y_train = np.array([0, 1, 0, 1])
-        clf = SVC(probability=True)
+        clf = SVC(C=1.0, kernel="rbf", gamma="scale", probability=True, random_state=0)
         clf.fit(X_train, y_train)
 
         scaler = StandardScaler()
@@ -325,7 +325,7 @@ class TestPredictFromBundle:
 
         X_train = np.array([[1, 2], [3, 4], [5, 6], [7, 8]])
         y_train = np.array([0.1, 0.5, 0.7, 0.9])
-        clf = SVR()
+        clf = SVR(C=1.0, kernel="rbf", gamma="scale")
         clf.fit(X_train, y_train)
 
         bundle = {

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -57,9 +57,11 @@ class DummyExperiment:
         return DummyExperiment(self.config)
 
     def analyse_features(self, needs_feats):
+        # Test double hook intentionally does nothing.
         pass
 
     def store_report(self):
+        # Test double hook intentionally does nothing.
         pass
 
 
@@ -286,12 +288,14 @@ def test_get_importance_caches_result(tmp_path):
     from sklearn.tree import DecisionTreeClassifier
 
     analyser = _make_analyser(tmp_path)
-    model = DecisionTreeClassifier(random_state=0)
+    model = DecisionTreeClassifier(random_state=0, ccp_alpha=0.0)
 
     with patch.object(analyser.util, "get_path", return_value=str(tmp_path) + "/"):
         importance1 = analyser._get_importance(model, permutation=False)
         # Tamper with the cache to confirm second call reads from disk
-        cache_path = os.path.join(str(tmp_path), "cache", "importance_DecisionTreeClassifier.pkl")
+        cache_path = os.path.join(
+            str(tmp_path), "cache", "importance_DecisionTreeClassifier.pkl"
+        )
         sentinel = np.array([99.0, 99.0])
         with open(cache_path, "wb") as f:
             pickle.dump(sentinel, f)
@@ -306,7 +310,7 @@ def test_get_importance_perm_separate_cache(tmp_path):
     from sklearn.tree import DecisionTreeClassifier
 
     analyser = _make_analyser(tmp_path)
-    model = DecisionTreeClassifier(random_state=0)
+    model = DecisionTreeClassifier(random_state=0, ccp_alpha=0.0)
 
     with patch.object(analyser.util, "get_path", return_value=str(tmp_path) + "/"):
         analyser._get_importance(model, permutation=False)

--- a/tests/test_plot_distributions.py
+++ b/tests/test_plot_distributions.py
@@ -64,7 +64,7 @@ class TestPlotDistributionsStats:
 
     def test_result_file_created(self, tmp_path):
         """A result file is created for a categorical-label vs continuous-attribute pair."""
-        plots, res_dir = self._make_plots(tmp_path)
+        plots, _ = self._make_plots(tmp_path)
         df = _make_df()
         glob_conf.config["EXPL"]["value_counts"] = "[['age']]"
 

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -2,10 +2,15 @@
 
 import configparser
 import logging
+import os
 
+import numpy as np
+import pandas as pd
 import pytest
 
+import audeer
 import nkululeko.glob_conf as glob_conf
+import nkululeko.utils.util as util_mod
 from nkululeko.utils.util import Util
 
 
@@ -224,8 +229,6 @@ class TestNumericHelpers:
 class TestSetupLogging:
     def _reset_logger(self):
         """Remove all handlers from the shared module logger between tests."""
-        import nkululeko.utils.util as util_mod
-
         logger = logging.getLogger(util_mod.__name__)
         for h in logger.handlers[:]:
             h.close()
@@ -238,8 +241,6 @@ class TestSetupLogging:
         self._reset_logger()
 
     def test_file_handler_created_when_exp_config_present(self, tmp_path):
-        import nkululeko.utils.util as util_mod
-
         glob_conf.config["EXP"]["root"] = str(tmp_path)
         glob_conf.config["EXP"]["name"] = "logtest"
         Util("test")
@@ -251,8 +252,6 @@ class TestSetupLogging:
         assert file_handlers[0].baseFilename.endswith(".log")
 
     def test_no_duplicate_file_handler_on_second_util(self, tmp_path):
-        import nkululeko.utils.util as util_mod
-
         glob_conf.config["EXP"]["root"] = str(tmp_path)
         glob_conf.config["EXP"]["name"] = "logtest"
         Util("test")
@@ -264,8 +263,6 @@ class TestSetupLogging:
         assert len(file_handlers) == 1
 
     def test_file_handler_replaced_when_experiment_changes(self, tmp_path):
-        import nkululeko.utils.util as util_mod
-
         # First experiment
         glob_conf.config["EXP"]["root"] = str(tmp_path)
         glob_conf.config["EXP"]["name"] = "exp_one"
@@ -288,8 +285,6 @@ class TestSetupLogging:
         assert "exp_two" in second_handlers[0].baseFilename
 
     def test_no_file_handler_without_config(self, tmp_path):
-        import nkululeko.utils.util as util_mod
-
         glob_conf.config = None
         Util("test", has_config=False)
         logger = logging.getLogger(util_mod.__name__)
@@ -299,9 +294,6 @@ class TestSetupLogging:
         assert len(file_handlers) == 0
 
     def test_oserror_falls_back_to_console_only(self, tmp_path, monkeypatch):
-        import nkululeko.utils.util as util_mod
-        import audeer
-
         glob_conf.config["EXP"]["root"] = str(tmp_path)
         glob_conf.config["EXP"]["name"] = "logtest"
 
@@ -384,8 +376,6 @@ class TestGetPath:
         glob_conf.config["EXP"]["root"] = str(tmp_path)
         glob_conf.config["EXP"]["name"] = "newexp"
         u = Util("test")
-        import os
-
         path = u.get_path("res_dir")
         assert os.path.isdir(path)
 
@@ -398,8 +388,6 @@ class TestGetPath:
 class TestCheckClassLabel:
     def test_renames_class_label_to_target(self):
         u = Util("test")
-        import pandas as pd
-
         df = pd.DataFrame({"emotion": [1, 2], "class_label": ["A", "B"]})
         result = u.check_class_label(df)
         assert "class_label" not in result.columns
@@ -409,8 +397,6 @@ class TestCheckClassLabel:
 
     def test_no_class_label_column_unchanged(self):
         u = Util("test")
-        import pandas as pd
-
         df = pd.DataFrame({"emotion": [1, 2, 3], "other": [4, 5, 6]})
         result = u.check_class_label(df)
         assert list(result.columns) == ["emotion", "other"]
@@ -419,8 +405,6 @@ class TestCheckClassLabel:
         # Remove the target key so config_val returns None (the default)
         del glob_conf.config["DATA"]["target"]
         u = Util("test")
-        import pandas as pd
-
         df = pd.DataFrame({"emotion": [1], "class_label": ["A"]})
         result = u.check_class_label(df)
         # target is None → condition is False, no rename
@@ -455,6 +439,117 @@ class TestConfigValData:
         u = Util("test")
         result = u.config_val_data("emodb", "", "fallback")
         assert result == "/direct/path"
+
+
+# ---------------------------------------------------------------------------
+# handle_nan()
+# ---------------------------------------------------------------------------
+
+
+class TestHandleNan:
+    @pytest.fixture(autouse=True)
+    def reset_nan_strategy(self):
+        """Remove any nan_strategy override after each test."""
+        yield
+        glob_conf.config.remove_option("FEATS", "nan_strategy")
+
+    def test_no_nan_returns_unchanged(self):
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 2.0], "b": [3.0, 4.0]})
+        result = u.handle_nan(df, context="test")
+        pd.testing.assert_frame_equal(result, df)
+
+    def test_default_strategy_fills_with_zero(self):
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, np.nan], "b": [np.nan, 4.0]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[1, 0] == pytest.approx(0.0)
+        assert result.iloc[0, 1] == pytest.approx(0.0)
+
+    def test_mean_strategy(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "mean"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 3.0, np.nan], "b": [2.0, np.nan, 6.0]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[2, 0] == pytest.approx(2.0)  # mean of 1, 3
+        assert result.iloc[1, 1] == pytest.approx(4.0)  # mean of 2, 6
+
+    def test_median_strategy(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "median"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 3.0, 5.0, np.nan]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[3, 0] == pytest.approx(3.0)  # median of 1, 3, 5
+
+    def test_mean_strategy_handles_non_numeric_columns(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "mean"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 3.0, np.nan], "b": ["x", None, "z"]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[2, 0] == pytest.approx(2.0)
+        assert result.iloc[1, 1] == pytest.approx(0.0)
+
+    def test_invalid_strategy_falls_back_to_zero_and_logs_actual_strategy(self, caplog):
+        glob_conf.config["FEATS"]["nan_strategy"] = "invalid"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, np.nan]})
+        with caplog.at_level(logging.WARNING):
+            result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[1, 0] == pytest.approx(0.0)
+        assert "unknown NaN strategy 'invalid'" in caplog.text
+        assert "strategy 'zero'" in caplog.text
+
+    def test_drop_strategy_can_be_disallowed_to_preserve_row_alignment(self, caplog):
+        glob_conf.config["FEATS"]["nan_strategy"] = "drop"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, np.nan], "b": [3.0, 4.0]})
+        with caplog.at_level(logging.WARNING):
+            result = u.handle_nan(df, context="Model, train", allow_drop=False)
+        assert len(result) == 2
+        assert not result.isna().any().any()
+        assert result.iloc[1, 0] == pytest.approx(0.0)
+        assert "drop" in caplog.text
+        assert "misalign features and labels" in caplog.text
+
+    def test_drop_strategy(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "drop"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, np.nan, 3.0], "b": [4.0, 5.0, 6.0]})
+        result = u.handle_nan(df, context="test")
+        assert len(result) == 2
+        assert not result.isna().any().any()
+
+    def test_warns_with_count_and_percentage(self, caplog):
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, np.nan], "b": [np.nan, 4.0]})
+        with caplog.at_level(logging.WARNING):
+            u.handle_nan(df, context="Model, train")
+        assert "2 NaN values" in caplog.text
+        assert "50.0%" in caplog.text
+        assert "Model, train" in caplog.text
+
+    def test_mean_strategy_all_nan_column_falls_back_to_zero(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "mean"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 3.0], "b": [np.nan, np.nan]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[0, 1] == pytest.approx(0.0)
+        assert result.iloc[1, 1] == pytest.approx(0.0)
+
+    def test_median_strategy_all_nan_column_falls_back_to_zero(self):
+        glob_conf.config["FEATS"]["nan_strategy"] = "median"
+        u = Util("test")
+        df = pd.DataFrame({"a": [1.0, 3.0], "b": [np.nan, np.nan]})
+        result = u.handle_nan(df, context="test")
+        assert not result.isna().any().any()
+        assert result.iloc[0, 1] == pytest.approx(0.0)
+        assert result.iloc[1, 1] == pytest.approx(0.0)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
* fix: elevate NaN handling from debug to warning with configurable strategy

- Add Util.handle_nan() method supporting zero/mean/median/drop strategies
- Add [FEATS] nan_strategy INI config option (default: zero)
- Replace all debug-level NaN messages with warnings including count and %
- Update models: model.py, model_xgb.py, model_mlp.py, model_mlp_regression.py, model_adm.py
- Update feature extractors: feats_import.py, feats_praat.py, feats_analyser.py
- Update utility functions: stats.py, feats_praat_core.py
- Add comprehensive tests for handle_nan in tests/utils/test_util.py

* fix: add zero fallback for mean/median strategy when all values are NaN

Address code review feedback:
- Chain .fillna(0) after mean/median fillna to handle all-NaN columns
- Add test for all-NaN column edge case

* style: fix isort and black formatting issues

Run isort --profile black and black on all modified files to pass CI checks.

* fix: move inline imports to module level to fix SonarQube reliability

* fix: address code review - add NaN fallback comments, add test cleanup fixture

* fix: move inline imports to module level to resolve SonarQube C reliability

* fix: move inline imports to module level in TestSetupLogging to resolve SonarQube C reliability

* fix: address NaN review and PR 52 CI failures

* refactor: centralize model NaN handling

---------