### PR TITLE
Fix Util.error() print path inconsistency and add missing pytest cove…

### DIFF
--- a/examples/exp_agedb_class_os_xgb.ini
+++ b/examples/exp_agedb_class_os_xgb.ini
@@ -11,6 +11,7 @@ databases = ['emodb']
 emodb = ./data/emodb/emodb
 #emodb.split_strategy = specified
 emodb.split_strategy = balanced
+emodb.files_tables = ['files']
 balance = {'age':1}
 emodb.test_tables = ['emotion.categories.test.gold_standard']
 emodb.train_tables = ['emotion.categories.train.gold_standard']

--- a/nkululeko/augment.py
+++ b/nkululeko/augment.py
@@ -5,11 +5,13 @@ import argparse
 import ast
 import configparser
 import os
+import sys
 
 import pandas as pd
 
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -91,7 +93,11 @@ def main():
     parser.add_argument("--config", default="exp.ini", help="The base configuration")
     args = parser.parse_args()
     config_file = args.config if args.config is not None else "exp.ini"
-    doit(config_file)
+    try:
+        doit(config_file)
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/data/dataset.py
+++ b/nkululeko/data/dataset.py
@@ -622,8 +622,16 @@ class Dataset:
 
     def split_speakers(self):
         """One way to split train and eval sets: Specify percentage of evaluation speakers"""
-        test_percent = int(self.util.config_val_data(self.name, "test_size", 20))
         df = self.df
+        if "speaker" not in df.columns:
+            self.util.warn(
+                f"split_strategy is speaker_split but {self.name} has no speaker"
+                " column — using all samples as test split"
+            )
+            self.df_test = df
+            self.df_train = pd.DataFrame()
+            return
+        test_percent = int(self.util.config_val_data(self.name, "test_size", 20))
         s_num = df.speaker.nunique()
         test_num = int(s_num * (test_percent / 100))
         test_spkrs = sample(list(df.speaker.unique()), test_num)
@@ -739,6 +747,8 @@ class Dataset:
             return df
         """Rename the labels and remove the ones that are not needed."""
         target = glob_conf.config["DATA"]["target"]
+        if target not in df.columns:
+            return df
         # see if a special mapping should be used
         mappings = self.util.config_val_data(self.name, "mapping", False)
         if mappings:

--- a/nkululeko/data/dataset_csv.py
+++ b/nkululeko/data/dataset_csv.py
@@ -87,7 +87,7 @@ class Dataset_CSV(Dataset):
             self.got_target = True
         else:
             self.got_target = False
-        self.is_labeled = self.got_target
+        self.is_labeled = self.got_target and (self.target in self.df.columns)
         self.start_fresh = eval(self.util.config_val("DATA", "no_reuse", "False"))
         is_index = False
         try:

--- a/nkululeko/ensemble.py
+++ b/nkululeko/ensemble.py
@@ -18,6 +18,7 @@ Raises:
 """
 
 import configparser
+import sys
 import time
 from argparse import ArgumentParser
 from typing import List
@@ -28,6 +29,7 @@ from sklearn.metrics import balanced_accuracy_score, classification_report
 
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 # import torch
@@ -351,18 +353,22 @@ def main():
 
     args = parser.parse_args()
 
-    start = time.time()
+    try:
+        start = time.time()
 
-    ensemble_preds = ensemble_predictions(
-        args.config, args.method, args.threshold, args.weights, args.no_labels
-    )
+        ensemble_preds = ensemble_predictions(
+            args.config, args.method, args.threshold, args.weights, args.no_labels
+        )
 
-    # save to csv
-    ensemble_preds.to_csv(args.outfile, index=False)
-    Util("ensemble").debug(f"Ensemble predictions saved to: {args.outfile}")
-    Util("ensemble").debug(f"Ensemble done, used {time.time() - start:.2f} seconds")
+        # save to csv
+        ensemble_preds.to_csv(args.outfile, index=False)
+        Util("ensemble").debug(f"Ensemble predictions saved to: {args.outfile}")
+        Util("ensemble").debug(f"Ensemble done, used {time.time() - start:.2f} seconds")
 
-    Util("ensemble").debug("DONE")
+        Util("ensemble").debug("DONE")
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/explore.py
+++ b/nkululeko/explore.py
@@ -28,8 +28,11 @@ import argparse
 import configparser
 from pathlib import Path
 
+import sys
+
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -41,74 +44,78 @@ def main():
     args = parser.parse_args()
     config_file = args.config if args.config is not None else "exp.ini"
 
-    if not Path(config_file).is_file():
-        print(f"ERROR: no such file: {config_file}")
-        exit()
-
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    expr = Experiment(config)
-    module = "explore"
-    expr.set_module(module)
-    util = Util(module)
-    util.debug(
-        f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
-    )
-
-    if util.config_val("EXP", "no_warnings", False):
-        import warnings
-
-        warnings.filterwarnings("ignore")
-    needs_feats = False
-    experiment_loaded = False
     try:
-        # load the experiment
-        expr.load(f"{util.get_save_name()}")
-        expr.util.set_config(config)
-        needs_feats = True
-        experiment_loaded = True
-    except FileNotFoundError:
-        # first time: load the data
-        expr.load_datasets()
+        if not Path(config_file).is_file():
+            print(f"ERROR: no such file: {config_file}")
+            sys.exit(1)
 
-        # split into train and test
-        expr.fill_train_and_tests()
+        config = configparser.ConfigParser()
+        config.read(config_file)
+        expr = Experiment(config)
+        module = "explore"
+        expr.set_module(module)
+        util = Util(module)
         util.debug(
-            f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}"
+            f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
         )
 
-    # Check exploration settings regardless of whether experiment was loaded or not
-    plot_feats = eval(util.config_val("EXPL", "feature_distributions", "False"))
-    tsne_plot = eval(util.config_val("EXPL", "tsne", "False"))
-    umap_plot = eval(util.config_val("EXPL", "umap", "False"))
-    pca_plot = eval(util.config_val("EXPL", "pca", "False"))
-    scatter = eval(util.config_val("EXPL", "scatter", "False"))
-    shap = eval(util.config_val("EXPL", "shap", "False"))
-    model_type = util.config_val("EXPL", "model", False)
-    plot_tree = eval(util.config_val("EXPL", "plot_tree", "False"))
+        if util.config_val("EXP", "no_warnings", False):
+            import warnings
 
-    if (
-        plot_feats
-        or tsne_plot
-        or umap_plot
-        or pca_plot
-        or scatter
-        or model_type
-        or plot_tree
-        or shap
-    ):
-        # these investigations need features to explore
-        if not experiment_loaded or not needs_feats:
-            expr.extract_feats()
-        needs_feats = True
-        # explore
-        if shap:
-            # SHAP analysis requires a trained model
-            expr.init_runmanager()
-            expr.runmgr.do_runs()
-    expr.analyse_features(needs_feats)
-    expr.store_report()
-    print("DONE")
+            warnings.filterwarnings("ignore")
+        needs_feats = False
+        experiment_loaded = False
+        try:
+            # load the experiment
+            expr.load(f"{util.get_save_name()}")
+            expr.util.set_config(config)
+            needs_feats = True
+            experiment_loaded = True
+        except FileNotFoundError:
+            # first time: load the data
+            expr.load_datasets()
+
+            # split into train and test
+            expr.fill_train_and_tests()
+            util.debug(
+                f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}"
+            )
+
+        # Check exploration settings regardless of whether experiment was loaded or not
+        plot_feats = eval(util.config_val("EXPL", "feature_distributions", "False"))
+        tsne_plot = eval(util.config_val("EXPL", "tsne", "False"))
+        umap_plot = eval(util.config_val("EXPL", "umap", "False"))
+        pca_plot = eval(util.config_val("EXPL", "pca", "False"))
+        scatter = eval(util.config_val("EXPL", "scatter", "False"))
+        shap = eval(util.config_val("EXPL", "shap", "False"))
+        model_type = util.config_val("EXPL", "model", False)
+        plot_tree = eval(util.config_val("EXPL", "plot_tree", "False"))
+
+        if (
+            plot_feats
+            or tsne_plot
+            or umap_plot
+            or pca_plot
+            or scatter
+            or model_type
+            or plot_tree
+            or shap
+        ):
+            # these investigations need features to explore
+            if not experiment_loaded or not needs_feats:
+                expr.extract_feats()
+            needs_feats = True
+            # explore
+            if shap:
+                # SHAP analysis requires a trained model
+                expr.init_runmanager()
+                expr.runmgr.do_runs()
+        expr.analyse_features(needs_feats)
+        expr.store_report()
+        print("DONE")
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/export.py
+++ b/nkululeko/export.py
@@ -5,6 +5,7 @@ import argparse
 import configparser
 import os
 import shutil
+import sys
 
 import audeer
 import audiofile
@@ -12,7 +13,51 @@ import pandas as pd
 
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
+
+
+def _export_file(file, file_dir, file_name, target_root, orig_root):
+    """Build the destination path for an exported file and return its
+    target-root-relative path."""
+    wav_folder = f"{target_root}/{os.path.basename(os.path.normpath(orig_root))}"
+    audeer.mkdir(wav_folder)
+    new_rel_path = file_dir[file_dir.index(orig_root) + 1 + len(orig_root) :]
+    new_file_path = f"{wav_folder}/{new_rel_path}"
+    audeer.mkdir(new_file_path)
+    new_file_name = f"{new_file_path}/{file_name}"
+    return new_file_name
+
+
+def _process_split(df, split, segments_as_files, target_root, orig_root):
+    """Export the audio of one split and return the dataframe re-indexed to the
+    exported file paths."""
+    files = []
+    for file, start, end in df.index.to_list():
+        file_dir = os.path.dirname(file)
+        if segments_as_files:
+            signal, sampling_rate = audiofile.read(
+                file,
+                offset=start.total_seconds(),
+                duration=(end - start).total_seconds(),
+                always_2d=True,
+            )
+            file_name = os.path.splitext(file)[0] + "_" + start.total_seconds() + ".wav"
+            new_file_name = _export_file(
+                file, file_dir, file_name, target_root, orig_root
+            )
+            audiofile.write(new_file_name, signal, sampling_rate)
+        else:
+            file_name = os.path.basename(file)
+            new_file_name = _export_file(
+                file, file_dir, file_name, target_root, orig_root
+            )
+            if not os.path.exists(new_file_name):
+                shutil.copyfile(file, new_file_name)
+        files.append(os.path.relpath(new_file_name, target_root))
+    df = df.set_index(df.index.set_levels(files, level="file"))
+    df["split"] = split
+    return df
 
 
 def main():
@@ -21,97 +66,57 @@ def main():
     args = parser.parse_args()
     config_file = args.config if args.config is not None else "exp.ini"
 
-    if not os.path.isfile(config_file):
-        print(f"ERROR: no such file: {config_file}")
-        exit()
+    try:
+        if not os.path.isfile(config_file):
+            print(f"ERROR: no such file: {config_file}")
+            sys.exit(1)
 
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    expr = Experiment(config)
-    util = Util("export")
-    util.debug(
-        f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
-    )
+        config = configparser.ConfigParser()
+        config.read(config_file)
+        expr = Experiment(config)
+        util = Util("export")
+        util.debug(
+            f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
+        )
 
-    if util.config_val("EXP", "no_warnings", False):
-        import warnings
+        if util.config_val("EXP", "no_warnings", False):
+            import warnings
 
-        warnings.filterwarnings("ignore")
+            warnings.filterwarnings("ignore")
 
-    # load the data
-    expr.load_datasets()
+        # load the data
+        expr.load_datasets()
 
-    # split into train and test
-    expr.fill_train_and_tests()
-    util.debug(f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}")
+        # split into train and test
+        expr.fill_train_and_tests()
+        util.debug(f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}")
 
-    # export
-    df_train = expr.df_train
-    df_test = expr.df_test
-    target_root = util.config_val("EXPORT", "root", "./exported_data/")
-    orig_root = util.config_val("EXPORT", "orig_root", None)
-    data_name = util.config_val("EXPORT", "data_name", "export")
-    segments_as_files = eval(util.config_val("EXPORT", "segments_as_files", "False"))
-    audeer.mkdir(target_root)
-    splits = {"train": df_train, "test": df_test}
-    df_all = pd.DataFrame()
-    for split in splits:
-        files = []
-        df = splits[split]
-        for idx, (file, start, end) in enumerate(df.index.to_list()):
-            file_dir = os.path.dirname(file)
-            if segments_as_files:
-                signal, sampling_rate = audiofile.read(
-                    file,
-                    offset=start.total_seconds(),
-                    duration=(end - start).total_seconds(),
-                    always_2d=True,
-                )
-                file_name = (
-                    os.path.splitext(file)[0] + "_" + start.total_seconds() + ".wav"
-                )
-                wav_folder = (
-                    f"{target_root}/{os.path.basename(os.path.normpath(orig_root))}"
-                )
-                audeer.mkdir(wav_folder)
-                new_rel_path = file_dir[
-                    file_dir.index(orig_root) + 1 + len(orig_root) :
-                ]
-                new_file_path = f"{wav_folder}/{new_rel_path}"
-                audeer.mkdir(new_file_path)
-                new_file_name = f"{new_file_path}/{file_name}"
-                audiofile.write(new_file_name, signal, sampling_rate)
-                new_file_name = os.path.relpath(new_file_name, target_root)
-                files.append(new_file_name)
-            else:
-                file_name = os.path.basename(file)
-                wav_folder = (
-                    f"{target_root}/{os.path.basename(os.path.normpath(orig_root))}"
-                )
-                audeer.mkdir(wav_folder)
-                new_rel_path = file_dir[
-                    file_dir.index(orig_root) + 1 + len(orig_root) :
-                ]
-                new_file_path = f"{wav_folder}/{new_rel_path}"
-                audeer.mkdir(new_file_path)
-                new_file_name = f"{new_file_path}/{file_name}"
-                if not os.path.exists(new_file_name):
-                    shutil.copyfile(file, new_file_name)
-                new_file_name = os.path.relpath(new_file_name, target_root)
-                files.append(new_file_name)
-        df = df.set_index(df.index.set_levels(files, level="file"))
-        df["split"] = split
-        df_all = pd.concat([df_all, df])
-    # remove encoded labels
-    target = util.config_val("DATA", "target", "emotion")
-    if "class_label" in df_all.columns:
-        df_all = df_all.drop(columns=[target])
-        df_all = df_all.rename(columns={"class_label": target})
+        # export
+        df_train = expr.df_train
+        df_test = expr.df_test
+        target_root = util.config_val("EXPORT", "root", "./exported_data/")
+        orig_root = util.config_val("EXPORT", "orig_root", None)
+        data_name = util.config_val("EXPORT", "data_name", "export")
+        segments_as_files = eval(util.config_val("EXPORT", "segments_as_files", "False"))
+        audeer.mkdir(target_root)
+        splits = {"train": df_train, "test": df_test}
+        df_all = pd.DataFrame()
+        for split, df in splits.items():
+            df = _process_split(df, split, segments_as_files, target_root, orig_root)
+            df_all = pd.concat([df_all, df])
+        # remove encoded labels
+        target = util.config_val("DATA", "target", "emotion")
+        if "class_label" in df_all.columns:
+            df_all = df_all.drop(columns=[target])
+            df_all = df_all.rename(columns={"class_label": target})
 
-    df_all.to_csv(f"{target_root}/{data_name}.csv")
-    util.debug(f"saved {data_name}.csv to {target_root}, {df.shape[0]} samples.")
+        df_all.to_csv(f"{target_root}/{data_name}.csv")
+        util.debug(f"saved {data_name}.csv to {target_root}, {df.shape[0]} samples.")
 
-    print("DONE")
+        print("DONE")
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/export.py
+++ b/nkululeko/export.py
@@ -42,7 +42,7 @@ def _process_split(df, split, segments_as_files, target_root, orig_root):
                 duration=(end - start).total_seconds(),
                 always_2d=True,
             )
-            file_name = os.path.splitext(file)[0] + "_" + start.total_seconds() + ".wav"
+            file_name = os.path.splitext(file)[0] + "_" + str(start.total_seconds()) + ".wav"
             new_file_name = _export_file(
                 file, file_dir, file_name, target_root, orig_root
             )

--- a/nkululeko/multidb.py
+++ b/nkululeko/multidb.py
@@ -13,6 +13,7 @@ import argparse
 import ast
 import configparser
 import os
+import sys
 
 import matplotlib.cm as cm
 import matplotlib.pyplot as plt
@@ -22,6 +23,7 @@ import seaborn as sn
 
 from nkululeko.aug_train import doit as aug_train
 from nkululeko.nkululeko import doit as nkulu
+from nkululeko.utils.errors import NkululukoError
 
 
 def main(src_dir):
@@ -38,89 +40,93 @@ def main(src_dir):
     # test if the configuration file exists
     if not os.path.isfile(config_file):
         print(f"ERROR: no such file: {config_file}")
-        exit()
+        sys.exit(1)
 
-    config = configparser.ConfigParser()
-    config.read(config_file)
-    datasets = config["EXP"]["databases"]
-    datasets = ast.literal_eval(datasets)
     try:
-        use_splits = eval(config["EXP"]["use_splits"])
-    except KeyError:
-        use_splits = False
-    dim = len(datasets)
-    results = np.zeros(dim * dim).reshape([dim, dim])
-    last_epochs = np.zeros(dim * dim).reshape([dim, dim])
-    # check if some data should be added to training
-    try:
-        extra_trains = config["CROSSDB"]["train_extra"]
-    except KeyError:
-        extra_trains = False
+        config = configparser.ConfigParser()
+        config.read(config_file)
+        datasets = config["EXP"]["databases"]
+        datasets = ast.literal_eval(datasets)
+        try:
+            use_splits = eval(config["EXP"]["use_splits"])
+        except KeyError:
+            use_splits = False
+        dim = len(datasets)
+        results = np.zeros(dim * dim).reshape([dim, dim])
+        last_epochs = np.zeros(dim * dim).reshape([dim, dim])
+        # check if some data should be added to training
+        try:
+            extra_trains = config["CROSSDB"]["train_extra"]
+        except KeyError:
+            extra_trains = False
 
-    for i in range(dim):
-        for j in range(dim):
-            # initialize config
-            config = None
-            config = configparser.ConfigParser()
-            config.read(config_file)
-            if i == j:
-                dataset = datasets[i]
-                print(f"running {dataset}")
-                if extra_trains:
-                    extra_trains_1 = extra_trains.removeprefix("[").removesuffix("]")
-                    config["DATA"]["databases"] = f"['{dataset}', {extra_trains_1}]"
-                    extra_trains_2 = ast.literal_eval(extra_trains)
-                    for extra_train in extra_trains_2:
-                        config["DATA"][f"{extra_train}.split_strategy"] = "train"
-                else:
-                    config["DATA"]["databases"] = f"['{dataset}']"
-                config["EXP"]["name"] = dataset
-            else:
-                train = datasets[i]
-                test = datasets[j]
-                print(f"running train: {train}, test: {test}")
-                if extra_trains:
-                    extra_trains_1 = extra_trains.removeprefix("[").removesuffix("]")
-                    config["DATA"]["databases"] = (
-                        f"['{train}', '{test}', {extra_trains_1}]"
-                    )
-                    if use_splits:
-                        config["DATA"][f"{test}.as_test"] = "True"
-                        config["DATA"][f"{train}.as_train"] = "True"
+        for i in range(dim):
+            for j in range(dim):
+                # initialize config
+                config = None
+                config = configparser.ConfigParser()
+                config.read(config_file)
+                if i == j:
+                    dataset = datasets[i]
+                    print(f"running {dataset}")
+                    if extra_trains:
+                        extra_trains_1 = extra_trains.removeprefix("[").removesuffix("]")
+                        config["DATA"]["databases"] = f"['{dataset}', {extra_trains_1}]"
+                        extra_trains_2 = ast.literal_eval(extra_trains)
+                        for extra_train in extra_trains_2:
+                            config["DATA"][f"{extra_train}.split_strategy"] = "train"
                     else:
-                        config["DATA"][f"{test}.split_strategy"] = "test"
-                        config["DATA"][f"{train}.split_strategy"] = "train"
-                    extra_trains_2 = ast.literal_eval(extra_trains)
-                    for extra_train in extra_trains_2:
-                        config["DATA"][f"{extra_train}.split_strategy"] = "train"
+                        config["DATA"]["databases"] = f"['{dataset}']"
+                    config["EXP"]["name"] = dataset
                 else:
-                    config["DATA"]["databases"] = f"['{train}', '{test}']"
-                    if use_splits:
-                        config["DATA"][f"{test}.as_test"] = "True"
-                        config["DATA"][f"{train}.as_train"] = "True"
+                    train = datasets[i]
+                    test = datasets[j]
+                    print(f"running train: {train}, test: {test}")
+                    if extra_trains:
+                        extra_trains_1 = extra_trains.removeprefix("[").removesuffix("]")
+                        config["DATA"]["databases"] = (
+                            f"['{train}', '{test}', {extra_trains_1}]"
+                        )
+                        if use_splits:
+                            config["DATA"][f"{test}.as_test"] = "True"
+                            config["DATA"][f"{train}.as_train"] = "True"
+                        else:
+                            config["DATA"][f"{test}.split_strategy"] = "test"
+                            config["DATA"][f"{train}.split_strategy"] = "train"
+                        extra_trains_2 = ast.literal_eval(extra_trains)
+                        for extra_train in extra_trains_2:
+                            config["DATA"][f"{extra_train}.split_strategy"] = "train"
                     else:
-                        config["DATA"][f"{test}.split_strategy"] = "test"
-                        config["DATA"][f"{train}.split_strategy"] = "train"
-                config["EXP"]["name"] = f"{train}_vs_{test}"
+                        config["DATA"]["databases"] = f"['{train}', '{test}']"
+                        if use_splits:
+                            config["DATA"][f"{test}.as_test"] = "True"
+                            config["DATA"][f"{train}.as_train"] = "True"
+                        else:
+                            config["DATA"][f"{test}.split_strategy"] = "test"
+                            config["DATA"][f"{train}.split_strategy"] = "train"
+                    config["EXP"]["name"] = f"{train}_vs_{test}"
 
-            tmp_config = "tmp.ini"
-            with open(tmp_config, "w") as tmp_file:
-                config.write(tmp_file)
-            if config.has_section("AUGMENT"):
-                result, last_epoch = aug_train(tmp_config)
-            else:
-                result, last_epoch = nkulu(tmp_config)
-            results[i, j] = float(result)
-            last_epochs[i, j] = int(last_epoch)
-    print(repr(results))
-    print(repr(last_epochs))
-    root = os.path.join(config["EXP"]["root"], "")
-    try:
-        format = config["PLOT"]["format"]
-        plot_name = f"{root}/heatmap.{format}"
-    except KeyError:
-        plot_name = f"{root}/heatmap.png"
-    plot_heatmap(results, last_epochs, datasets, plot_name, config, datasets)
+                tmp_config = "tmp.ini"
+                with open(tmp_config, "w") as tmp_file:
+                    config.write(tmp_file)
+                if config.has_section("AUGMENT"):
+                    result, last_epoch = aug_train(tmp_config)
+                else:
+                    result, last_epoch = nkulu(tmp_config)
+                results[i, j] = float(result)
+                last_epochs[i, j] = int(last_epoch)
+        print(repr(results))
+        print(repr(last_epochs))
+        root = os.path.join(config["EXP"]["root"], "")
+        try:
+            format = config["PLOT"]["format"]
+            plot_name = f"{root}/heatmap.{format}"
+        except KeyError:
+            plot_name = f"{root}/heatmap.png"
+        plot_heatmap(results, last_epochs, datasets, plot_name, config, datasets)
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 def trunc_to_three(x):

--- a/nkululeko/nkululeko.py
+++ b/nkululeko/nkululeko.py
@@ -6,6 +6,7 @@ import argparse
 import ast
 import configparser
 import os
+import sys
 from pathlib import Path
 
 import numpy as np
@@ -13,6 +14,7 @@ import numpy as np
 import nkululeko.experiment as exp
 import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -140,7 +142,11 @@ def main():
         config_file = args.config
     else:
         config_file = cwd / "exp.ini"
-    doit(config_file)
+    try:
+        doit(config_file)
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/nkululeko.py
+++ b/nkululeko/nkululeko.py
@@ -62,11 +62,15 @@ def doit(config_file):
 
         best_model = expr.runmgr.get_best_model()
 
-        # Integer-encode the target column in-place so model.predict() can
-        # compare predictions against numeric ground-truth values.
-        expr.df_test[expr.target] = expr.label_encoder.transform(
-            expr.df_test[expr.target]
-        )
+        # Integer-encode the target column only if the test set has labels.
+        has_labels = expr.target in expr.df_test.columns
+        if has_labels:
+            expr.df_test[expr.target] = expr.label_encoder.transform(
+                expr.df_test[expr.target]
+            )
+        else:
+            # Unlabeled test set: add a dummy column so model.predict() can run.
+            expr.df_test[expr.target] = 0
         best_model.reset_test(expr.df_test, expr.feats_test)
         report = best_model.predict()
         report.set_id(best_model.run, best_model.epoch)
@@ -77,8 +81,9 @@ def doit(config_file):
             util.get_exp_name()
             + f"_{test_dbs_str}_{best_model.run}_{best_model.epoch:03d}_cnf"
         )
-        report.print_results(best_model.epoch, file_name=plot_name)
-        report.plot_confmatrix(plot_name, best_model.epoch)
+        if has_labels:
+            report.print_results(best_model.epoch, file_name=plot_name)
+            report.plot_confmatrix(plot_name, best_model.epoch)
 
         # Save result CSV: all original test columns plus decoded predictions.
         res_dir = util.get_path("res_dir")
@@ -87,16 +92,19 @@ def doit(config_file):
             plot_name.replace("_cnf", "_predictions") + ".csv",
         )
         result_df = expr.df_test.copy()
-        result_df[expr.target] = expr.label_encoder.inverse_transform(
-            result_df[expr.target].astype(int)
-        )
+        if has_labels:
+            result_df[expr.target] = expr.label_encoder.inverse_transform(
+                result_df[expr.target].astype(int)
+            )
+        else:
+            result_df = result_df.drop(columns=[expr.target])
         result_df["predicted"] = expr.label_encoder.inverse_transform(
             report.preds.astype(int)
         )
         result_df.to_csv(csv_path)
         util.debug(f"predictions CSV saved to: {csv_path}")
 
-        result = report.result.test
+        result = report.result.test if has_labels else 0.0
         print("DONE")
         return result, best_model.epoch
 

--- a/nkululeko/nkululeko.py
+++ b/nkululeko/nkululeko.py
@@ -144,8 +144,8 @@ def main():
         config_file = cwd / "exp.ini"
     try:
         doit(config_file)
-    except NkululukoError as e:
-        print(str(e))
+    except NkululukoError:
+        # Util.error() already logged the message before raising; just exit.
         sys.exit(1)
 
 

--- a/nkululeko/optim.py
+++ b/nkululeko/optim.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from nkululeko.constants import VERSION
 import nkululeko.glob_conf as glob_conf
 from nkululeko.optimizationrunner import OptimizationRunner
+from nkululeko.utils.errors import NkululukoError
 
 
 def doit(config_file):
@@ -52,7 +53,11 @@ def main():
     )
     args = parser.parse_args()
 
-    doit(args.config)
+    try:
+        doit(args.config)
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/predict.py
+++ b/nkululeko/predict.py
@@ -47,6 +47,7 @@ from tqdm import tqdm
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION, SAMPLING_RATE
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.files import find_files
 from nkululeko.utils.util import Util
 
@@ -167,53 +168,55 @@ def _build_parser():
 def main():
     args = _build_parser().parse_args()
 
-    # accept --file "a.mp3 b.wav" as a single space-separated argument
-    if args.file and len(args.file) == 1 and " " in args.file[0].strip():
-        args.file = args.file[0].split()
+    try:
+        # accept --file "a.mp3 b.wav" as a single space-separated argument
+        if args.file and len(args.file) == 1 and " " in args.file[0].strip():
+            args.file = args.file[0].split()
 
-    module_name = "predict"
-    config = _load_config(args)
-    if args.language:
-        _apply_language_override(config, args.language)
-    glob_conf.init_config(config)
-    glob_conf.set_module(module_name)
-    util = Util(module_name, has_config=True)
-    util.debug(f"nkululeko {VERSION}: {module_name}")
-    if args.language:
-        util.debug(
-            f"language override: EXP.language=PREDICT.target_language={args.language}"
-        )
+        module_name = "predict"
+        config = _load_config(args)
+        if args.language:
+            _apply_language_override(config, args.language)
+        glob_conf.init_config(config)
+        glob_conf.set_module(module_name)
+        util = Util(module_name, has_config=True)
+        util.debug(f"nkululeko {VERSION}: {module_name}")
+        if args.language:
+            util.debug(
+                f"language override: EXP.language=PREDICT.target_language={args.language}"
+            )
 
-    if args.ptype == "model" and not args.config:
-        util.error("--type model requires --config CONFIG.ini")
+        if args.ptype == "model" and not args.config:
+            util.error("--type model requires --config CONFIG.ini")
 
-    if args.ptype == "feats" and not args.model:
-        feats_type = util.config_val("FEATS", "type", None)
-        if feats_type is None:
-            util.error("--type feats requires --model or FEATS.type in --config")
-        args.model = _first_extractor(feats_type)
+        if args.ptype == "feats" and not args.model:
+            feats_type = util.config_val("FEATS", "type", None)
+            if feats_type is None:
+                util.error("--type feats requires --model or FEATS.type in --config")
+            args.model = _first_extractor(feats_type)
 
-    if args.mic:
-        _run_mic(args, util)
-    elif args.file:
-        _run_files(args.file, args, util)
-    elif args.folder:
-        _run_folder(args.folder, args, util)
-    elif args.list_path:
-        _run_list(args.list_path, args, util)
-    elif args.config:
-        # No explicit input — use the dataframe defined by the experiment
-        # config. EXP.sample_selection (default "all") picks train / test /
-        # all from the loaded dataset(s).
-        _run_from_config(args, util)
-    else:
-        util.error(
-            "no input given: provide one of --file, --folder, --list, --mic, "
-            "or --config (loads the dataframe defined by the experiment's "
-            "[DATA] section, selection via EXP.sample_selection)"
-        )
-
-    util.debug("DONE")
+        if args.mic:
+            _run_mic(args, util)
+        elif args.file:
+            _run_files(args.file, args, util)
+        elif args.folder:
+            _run_folder(args.folder, args, util)
+        elif args.list_path:
+            _run_list(args.list_path, args, util)
+        elif args.config:
+            # No explicit input — use the dataframe defined by the experiment
+            # config. EXP.sample_selection (default "all") picks train / test /
+            # all from the loaded dataset(s).
+            _run_from_config(args, util)
+        else:
+            util.error(
+                "no input given: provide one of --file, --folder, --list, --mic, "
+                "or --config (loads the dataframe defined by the experiment's "
+                "[DATA] section, selection via EXP.sample_selection)"
+            )
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 # ---------------------------------------------------------------------------

--- a/nkululeko/resample.py
+++ b/nkululeko/resample.py
@@ -25,6 +25,7 @@ original files.
 import argparse
 import configparser
 import os
+import sys
 
 import pandas as pd
 
@@ -33,6 +34,7 @@ import audformat
 from nkululeko.augmenting.resampler import Resampler
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.files import find_files
 from nkululeko.utils.util import Util
 
@@ -56,87 +58,91 @@ def main():
 
     if args.file is None and args.folder is None and args.config is None:
         print("ERROR: Either --file, --folder, or --config argument must be provided.")
-        exit()
+        sys.exit(1)
 
-    if args.file is not None:
-        # Load the audio file into a DataFrame
-        files = pd.Series([args.file])
-        df_sample = pd.DataFrame(index=files)
-        df_sample.index = audformat.utils.to_segmented_index(
-            df_sample.index, allow_nat=False
-        )
-
-        # Resample the audio file
-        util = Util("resampler", has_config=False)
-        util.debug(f"Resampling audio file: {args.file}")
-        rs = Resampler(df_sample, not_testing=True, replace=args.replace)
-        rs.resample()
-    elif args.folder is not None:
-        # Load all audio files in the directory and its subdirectories into a DataFrame
-        files = find_files(args.folder, relative=True, ext=["wav"])
-        files = pd.Series(files)
-        df_sample = pd.DataFrame(index=files)
-        df_sample.index = audformat.utils.to_segmented_index(
-            df_sample.index, allow_nat=False
-        )
-
-        # Resample the audio files
-        util = Util("resampler", has_config=False)
-        util.debug(f"Resampling audio files in directory: {args.folder}")
-        rs = Resampler(df_sample, not_testing=True, replace=args.replace)
-        rs.resample()
-    else:
-        # Existing code for handling INI file
-        config_file = args.config
-
-        # Test if the configuration file exists
-        if not os.path.isfile(config_file):
-            print(f"ERROR: no such file: {config_file}")
-            exit()
-
-        # Load one configuration per experiment
-        config = configparser.ConfigParser()
-        config.read(config_file)
-        # Create a new experiment
-        expr = Experiment(config)
-        module = "resample"
-        expr.set_module(module)
-        util = Util(module)
-        util.debug(
-            f"running {expr.name} from config {config_file}, nkululeko version"
-            f" {VERSION}"
-        )
-
-        if util.config_val("EXP", "no_warnings", False):
-            import warnings
-
-            warnings.filterwarnings("ignore")
-
-        # Load the data
-        expr.load_datasets()
-
-        # Split into train and test
-        expr.fill_train_and_tests()
-        util.debug(
-            f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}"
-        )
-
-        sample_selection = util.config_val("EXP", "sample_selection", "all")
-        if sample_selection == "all":
-            df = pd.concat([expr.df_train, expr.df_test])
-        elif sample_selection == "train":
-            df = expr.df_train
-        elif sample_selection == "test":
-            df = expr.df_test
-        else:
-            util.error(
-                f"unknown selection specifier {sample_selection}, should be [all |"
-                " train | test]"
+    try:
+        if args.file is not None:
+            # Load the audio file into a DataFrame
+            files = pd.Series([args.file])
+            df_sample = pd.DataFrame(index=files)
+            df_sample.index = audformat.utils.to_segmented_index(
+                df_sample.index, allow_nat=False
             )
-        util.debug(f"resampling {sample_selection}: {df.shape[0]} samples")
-        replace = util.config_val("RESAMPLE", "replace", "False")
-        rs = Resampler(df, replace=replace)
-        rs.resample()
+
+            # Resample the audio file
+            util = Util("resampler", has_config=False)
+            util.debug(f"Resampling audio file: {args.file}")
+            rs = Resampler(df_sample, not_testing=True, replace=args.replace)
+            rs.resample()
+        elif args.folder is not None:
+            # Load all audio files in the directory and its subdirectories into a DataFrame
+            files = find_files(args.folder, relative=True, ext=["wav"])
+            files = pd.Series(files)
+            df_sample = pd.DataFrame(index=files)
+            df_sample.index = audformat.utils.to_segmented_index(
+                df_sample.index, allow_nat=False
+            )
+
+            # Resample the audio files
+            util = Util("resampler", has_config=False)
+            util.debug(f"Resampling audio files in directory: {args.folder}")
+            rs = Resampler(df_sample, not_testing=True, replace=args.replace)
+            rs.resample()
+        else:
+            # Existing code for handling INI file
+            config_file = args.config
+
+            # Test if the configuration file exists
+            if not os.path.isfile(config_file):
+                print(f"ERROR: no such file: {config_file}")
+                sys.exit(1)
+
+            # Load one configuration per experiment
+            config = configparser.ConfigParser()
+            config.read(config_file)
+            # Create a new experiment
+            expr = Experiment(config)
+            module = "resample"
+            expr.set_module(module)
+            util = Util(module)
+            util.debug(
+                f"running {expr.name} from config {config_file}, nkululeko version"
+                f" {VERSION}"
+            )
+
+            if util.config_val("EXP", "no_warnings", False):
+                import warnings
+
+                warnings.filterwarnings("ignore")
+
+            # Load the data
+            expr.load_datasets()
+
+            # Split into train and test
+            expr.fill_train_and_tests()
+            util.debug(
+                f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}"
+            )
+
+            sample_selection = util.config_val("EXP", "sample_selection", "all")
+            if sample_selection == "all":
+                df = pd.concat([expr.df_train, expr.df_test])
+            elif sample_selection == "train":
+                df = expr.df_train
+            elif sample_selection == "test":
+                df = expr.df_test
+            else:
+                util.error(
+                    f"unknown selection specifier {sample_selection}, should be [all |"
+                    " train | test]"
+                )
+            util.debug(f"resampling {sample_selection}: {df.shape[0]} samples")
+            replace = util.config_val("RESAMPLE", "replace", "False")
+            rs = Resampler(df, replace=replace)
+            rs.resample()
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/segment.py
+++ b/nkululeko/segment.py
@@ -24,6 +24,7 @@ References:
 import argparse
 import configparser
 import os
+import sys
 
 import audeer
 import audiofile
@@ -34,6 +35,7 @@ from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
 import nkululeko.glob_conf as glob_conf
 from nkululeko.reporting.report_item import ReportItem
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 from nkululeko.utils.dataframe import segment_silence
 from nkululeko.plots import Plots
@@ -194,152 +196,156 @@ def main():
     )
     args = parser.parse_args()
 
-    if args.file is not None:
-        _run_file_mode(args)
-        return
+    try:
+        if args.file is not None:
+            _run_file_mode(args)
+            return
 
-    config_file = args.config if args.config is not None else "exp.ini"
+        config_file = args.config if args.config is not None else "exp.ini"
 
-    if not os.path.isfile(config_file):
-        print(f"ERROR: no such file: {config_file}")
-        exit()
+        if not os.path.isfile(config_file):
+            print(f"ERROR: no such file: {config_file}")
+            sys.exit(1)
 
-    config = configparser.ConfigParser()
-    config.read(config_file)
+        config = configparser.ConfigParser()
+        config.read(config_file)
 
-    _apply_cli_overrides(args, config)
-    expr = Experiment(config)
-    module = "segment"
-    expr.set_module(module)
-    util = Util(module)
-    util.debug(f"running {expr.name}, nkululeko version {VERSION}")
+        _apply_cli_overrides(args, config)
+        expr = Experiment(config)
+        module = "segment"
+        expr.set_module(module)
+        util = Util(module)
+        util.debug(f"running {expr.name}, nkululeko version {VERSION}")
 
-    if util.config_val("EXP", "no_warnings", False):
-        import warnings
+        if util.config_val("EXP", "no_warnings", False):
+            import warnings
 
-        warnings.filterwarnings("ignore")
+            warnings.filterwarnings("ignore")
 
-    # load the data
-    expr.load_datasets()
+        # load the data
+        expr.load_datasets()
 
-    # split into train and test
-    expr.fill_train_and_tests()
-    util.debug(f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}")
+        # split into train and test
+        expr.fill_train_and_tests()
+        util.debug(f"train shape : {expr.df_train.shape}, test shape:{expr.df_test.shape}")
 
-    def calc_dur(x):
-        starts = x[1]
-        ends = x[2]
-        return (ends - starts).total_seconds()
+        def calc_dur(x):
+            starts = x[1]
+            ends = x[2]
+            return (ends - starts).total_seconds()
 
-    # segment
-    segmented_file = util.config_val("SEGMENT", "result", "segmented")
+        # segment
+        segmented_file = util.config_val("SEGMENT", "result", "segmented")
 
-    method = util.config_val("SEGMENT", "method", "silero")
-    sample_selection = util.config_val("EXP", "sample_selection", "all")
-    if sample_selection == "all":
-        df = pd.concat([expr.df_train, expr.df_test])
-    elif sample_selection == "train":
-        df = expr.df_train
-    elif sample_selection == "test":
-        df = expr.df_test
-    else:
-        util.error(
-            f"unknown segmentation selection specifier {sample_selection},"
-            " should be [all | train | test]"
-        )
-    result_file = f"{expr.data_dir}/{segmented_file}"
-    if result_file.endswith(".csv"):
-        result_file = result_file[:-4]
-    seg_file_name = f"{result_file}.csv"
-    segment_silence_file_name = f"{result_file}_silence.csv"
-    if os.path.exists(f"{seg_file_name}") and os.path.exists(
-        f"{segment_silence_file_name}"
-    ):
-        util.debug(
-            f"reusing existing result file: {seg_file_name} and {segment_silence_file_name}"
-        )
-        df_seg = audformat.utils.read_csv(f"{seg_file_name}")
-        df_silence = audformat.utils.read_csv(f"{segment_silence_file_name}")
-    else:
-        util.debug(
-            f"segmenting {sample_selection}: {df.shape[0]} samples with {method}"
-        )
-        if method == "silero":
-            from nkululeko.segmenting.seg_silero import Silero_segmenter
-
-            segmenter = Silero_segmenter()
-            df_seg = segmenter.segment_dataframe(df)
-        elif method == "pyannote":
-            from nkululeko.segmenting.seg_pyannote import Pyannote_segmenter
-
-            segmenter = Pyannote_segmenter(config)
-            df_seg = segmenter.segment_dataframe(df)
+        method = util.config_val("SEGMENT", "method", "silero")
+        sample_selection = util.config_val("EXP", "sample_selection", "all")
+        if sample_selection == "all":
+            df = pd.concat([expr.df_train, expr.df_test])
+        elif sample_selection == "train":
+            df = expr.df_train
+        elif sample_selection == "test":
+            df = expr.df_test
         else:
-            util.error(f"unknown segmenter: {method}")
-        # segment also the gaps between segments to get a full coverage of the original audio
-        with_borders = util.config_val("SEGMENT", "include_silence_borders", "False")
-        with_borders = str(with_borders).lower() in ("true", "1", "yes")
-        df_silence = segment_silence(df_seg, with_borders=with_borders)
+            util.error(
+                f"unknown segmentation selection specifier {sample_selection},"
+                " should be [all | train | test]"
+            )
+        result_file = f"{expr.data_dir}/{segmented_file}"
+        if result_file.endswith(".csv"):
+            result_file = result_file[:-4]
+        seg_file_name = f"{result_file}.csv"
+        segment_silence_file_name = f"{result_file}_silence.csv"
+        if os.path.exists(f"{seg_file_name}") and os.path.exists(
+            f"{segment_silence_file_name}"
+        ):
+            util.debug(
+                f"reusing existing result file: {seg_file_name} and {segment_silence_file_name}"
+            )
+            df_seg = audformat.utils.read_csv(f"{seg_file_name}")
+            df_silence = audformat.utils.read_csv(f"{segment_silence_file_name}")
+        else:
+            util.debug(
+                f"segmenting {sample_selection}: {df.shape[0]} samples with {method}"
+            )
+            if method == "silero":
+                from nkululeko.segmenting.seg_silero import Silero_segmenter
 
-        # plot results
-        if "duration" not in df.columns:
-            df["duration"] = df.index.to_series().map(lambda x: calc_dur(x))
-        df_seg["duration"] = df_seg.index.to_series().map(lambda x: calc_dur(x))
-        df_silence["duration"] = df_silence.index.to_series().map(lambda x: calc_dur(x))
-        plots = Plots()
-        plots.plot_durations(
-            df, "original_durations", sample_selection, caption="Original durations"
+                segmenter = Silero_segmenter()
+                df_seg = segmenter.segment_dataframe(df)
+            elif method == "pyannote":
+                from nkululeko.segmenting.seg_pyannote import Pyannote_segmenter
+
+                segmenter = Pyannote_segmenter(config)
+                df_seg = segmenter.segment_dataframe(df)
+            else:
+                util.error(f"unknown segmenter: {method}")
+            # segment also the gaps between segments to get a full coverage of the original audio
+            with_borders = util.config_val("SEGMENT", "include_silence_borders", "False")
+            with_borders = str(with_borders).lower() in ("true", "1", "yes")
+            df_silence = segment_silence(df_seg, with_borders=with_borders)
+
+            # plot results
+            if "duration" not in df.columns:
+                df["duration"] = df.index.to_series().map(lambda x: calc_dur(x))
+            df_seg["duration"] = df_seg.index.to_series().map(lambda x: calc_dur(x))
+            df_silence["duration"] = df_silence.index.to_series().map(lambda x: calc_dur(x))
+            plots = Plots()
+            plots.plot_durations(
+                df, "original_durations", sample_selection, caption="Original durations"
+            )
+            plots.plot_durations(
+                df_seg,
+                "segmented_durations",
+                sample_selection,
+                caption="Segmented durations",
+            )
+            plots.plot_durations(
+                df_silence,
+                "silence_durations",
+                sample_selection,
+                caption="Silence durations",
+            )
+            if method == "pyannote":
+                util.debug(df_seg[["speaker", "duration"]].groupby(["speaker"]).sum())
+                plots.plot_speakers(df_seg, sample_selection)
+
+            # save files
+            # remove encoded labels
+            df_seg = util.check_class_label(df_seg)
+            df_silence = util.check_class_label(df_silence)
+            df_seg["duration"] = df_seg.index.to_series().map(lambda x: calc_dur(x))
+            df_seg.to_csv(f"{seg_file_name}")
+            df_silence["duration"] = df_silence.index.to_series().map(lambda x: calc_dur(x))
+            df_silence.to_csv(f"{segment_silence_file_name}")
+
+        if util.config_val("SEGMENT", "output_audio", "False").lower() in (
+            "true",
+            "1",
+            "yes",
+        ):
+            extract_audio_segments(df_seg, expr.data_dir, util)
+            extract_audio_segments(df_silence, expr.data_dir, util, is_silence=True)
+
+        num_before = df.shape[0]
+        num_after = df_seg.shape[0]
+        util.debug(
+            f"saved {seg_file_name} and {segment_silence_file_name} "
+            f" to {expr.data_dir}, {num_after} samples (was"
+            f" {num_before})"
         )
-        plots.plot_durations(
-            df_seg,
-            "segmented_durations",
-            sample_selection,
-            caption="Segmented durations",
+
+        glob_conf.report.add_item(
+            ReportItem(
+                "Data",
+                "Segmentation",
+                f"Segmented {num_before} samples to {num_after} segments",
+            )
         )
-        plots.plot_durations(
-            df_silence,
-            "silence_durations",
-            sample_selection,
-            caption="Silence durations",
-        )
-        if method == "pyannote":
-            util.debug(df_seg[["speaker", "duration"]].groupby(["speaker"]).sum())
-            plots.plot_speakers(df_seg, sample_selection)
-
-        # save files
-        # remove encoded labels
-        df_seg = util.check_class_label(df_seg)
-        df_silence = util.check_class_label(df_silence)
-        df_seg["duration"] = df_seg.index.to_series().map(lambda x: calc_dur(x))
-        df_seg.to_csv(f"{seg_file_name}")
-        df_silence["duration"] = df_silence.index.to_series().map(lambda x: calc_dur(x))
-        df_silence.to_csv(f"{segment_silence_file_name}")
-
-    if util.config_val("SEGMENT", "output_audio", "False").lower() in (
-        "true",
-        "1",
-        "yes",
-    ):
-        extract_audio_segments(df_seg, expr.data_dir, util)
-        extract_audio_segments(df_silence, expr.data_dir, util, is_silence=True)
-
-    num_before = df.shape[0]
-    num_after = df_seg.shape[0]
-    util.debug(
-        f"saved {seg_file_name} and {segment_silence_file_name} "
-        f" to {expr.data_dir}, {num_after} samples (was"
-        f" {num_before})"
-    )
-
-    glob_conf.report.add_item(
-        ReportItem(
-            "Data",
-            "Segmentation",
-            f"Segmented {num_before} samples to {num_after} segments",
-        )
-    )
-    expr.store_report()
-    print("DONE")
+        expr.store_report()
+        print("DONE")
+    except NkululukoError as e:
+        print(str(e))
+        sys.exit(1)
 
 
 if __name__ == "__main__":

--- a/nkululeko/utils/errors.py
+++ b/nkululeko/utils/errors.py
@@ -1,0 +1,10 @@
+# errors.py
+"""Custom exception classes for nkululeko."""
+
+
+class NkululukoError(RuntimeError):
+    """Raised when nkululeko encounters a fatal error.
+
+    This replaces direct sys.exit() calls so that nkululeko can be used
+    as a library without terminating the host process.
+    """

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -13,6 +13,7 @@ import audeer
 import numpy as np
 
 from nkululeko.utils.dataframe import DataFrameMixin
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.naming import NamingMixin
 from nkululeko.utils.storage import StorageMixin
 
@@ -262,11 +263,12 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         return False
 
     def error(self, message):
+        full_msg = f"ERROR: {self.caller}: {message}"
         if self.logger is not None:
-            self.logger.error(f"ERROR: {self.caller}: {message}")
+            self.logger.error(full_msg)
         else:
-            print(f"ERROR: {message}")
-        sys.exit()
+            print(full_msg)
+        raise NkululukoError(full_msg)
 
     def warn(self, message):
         if self.logger is not None:

--- a/tests/data_roots.ini
+++ b/tests/data_roots.ini
@@ -1,0 +1,16 @@
+[DATA]
+emodb = ./data/emodb/emodb
+emodb.split_strategy = specified
+emodb.test_tables = ['emotion.categories.test.gold_standard']
+emodb.train_tables = ['emotion.categories.train.gold_standard']
+emodb.mapping = {'anger':'angry', 'happiness':'happy', 'sadness':'sad', 'neutral':'neutral'}
+; crema-d = ./data/crema-d/crema-d/1.3.0/fe182b91/
+crema-d = ./data/crema-d/crema-d/1.3.0/d3b62a9b/
+crema-d.split_strategy = specified
+crema-d.colnames = {'sex':'gender'}
+crema-d.files_table = ['files']
+crema-d.target_tables = ['emotion.categories.desired.test','emotion.categories.desired.train', 'emotion.categories.desired.dev']
+crema-d.target_tables_append = True
+crema-d.test_tables = ['emotion.categories.desired.test']
+crema-d.train_tables = ['emotion.categories.desired.train', 'emotion.categories.desired.dev']
+crema-d.mapping = {'anger':'angry', 'happiness':'happy', 'sadness':'sad', 'neutral':'neutral'}

--- a/tests/test_modelrunner.py
+++ b/tests/test_modelrunner.py
@@ -8,6 +8,7 @@ import pytest
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.modelrunner import Modelrunner
+from nkululeko.utils.errors import NkululukoError
 
 
 @pytest.fixture(autouse=True)
@@ -120,7 +121,7 @@ class TestSelectModel:
     def test_unknown_model_raises(self, dummy_dfs):
         glob_conf.config["MODEL"]["type"] = "not_a_model"
         df_train, df_test, feats_train, feats_test = dummy_dfs
-        with pytest.raises(SystemExit):
+        with pytest.raises(NkululukoError):
             Modelrunner(df_train, df_test, feats_train, feats_test, run=0)
 
     def test_regression_model_for_regression_exp(self, dummy_dfs):

--- a/tests/test_modules.py
+++ b/tests/test_modules.py
@@ -19,12 +19,27 @@ class TestModules(unittest.TestCase):
         self.assertTrue(len(VERSION) > 0)
 
     def test_import(self):
-        """Test that main modules can be imported."""
+        """Test that all nkululeko modules can be imported.
+
+        The nkululeko package exposes these top-level entry-point modules:
+        ``nkululeko`` (``nkululeko.nkululeko``), ``ensemble``, ``multidb``,
+        ``explore``, ``augment``, ``aug_train``, ``predict``, ``segment``,
+        ``resample``, ``optim`` and ``flags``.  The core modules must import
+        with the package's base dependencies; the optional ones are skipped
+        gracefully when their optional extras (e.g. torch, torchaudio,
+        pyannote, silero) are not installed.
+        """
+        # Core entry-point modules (base dependencies only).
+        import nkululeko.aug_train  # noqa: F401
         import nkululeko.augment  # noqa: F401
         import nkululeko.explore  # noqa: F401
+        import nkululeko.flags  # noqa: F401
+        import nkululeko.multidb  # noqa: F401
         import nkululeko.nkululeko  # noqa: F401
+        import nkululeko.optim  # noqa: F401
         import nkululeko.predict  # noqa: F401
 
+        # Optional entry-point modules (may require optional extras).
         try:
             import nkululeko.resample  # noqa: F401
         except (ImportError, OSError):
@@ -33,12 +48,18 @@ class TestModules(unittest.TestCase):
         try:
             import nkululeko.segment  # noqa: F401
         except ImportError:
-            print("Skipping segment module import (may require optional dependencies)")
+            print(
+                "Skipping segment module import "
+                "(may require optional dependencies)"
+            )
 
         try:
             import nkululeko.ensemble  # noqa: F401
         except ImportError:
-            print("Skipping ensemble module import (may require optional dependencies)")
+            print(
+                "Skipping ensemble module import "
+                "(may require optional dependencies)"
+            )
 
         self.assertTrue(True)  # If imports succeed, test passes
 

--- a/tests/utils/test_dataframe.py
+++ b/tests/utils/test_dataframe.py
@@ -8,6 +8,7 @@ import numpy as np
 import pandas as pd
 
 import nkululeko.glob_conf as glob_conf
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -229,25 +230,25 @@ type = os
     def test_df_to_cont_dict_missing_column1(self):
         u = make_util()
         df = pd.DataFrame({"y": [3.0, 4.0]})
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(NkululukoError):
             u.df_to_cont_dict(df, "x", "y")
 
     def test_df_to_cont_dict_missing_column2(self):
         u = make_util()
         df = pd.DataFrame({"x": [1.0, 2.0]})
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(NkululukoError):
             u.df_to_cont_dict(df, "x", "y")
 
     def test_df_to_categorical_dict_missing_categorical_column(self):
         u = make_util()
         df = pd.DataFrame({"score": [0.8, 0.6]})
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(NkululukoError):
             u.df_to_categorical_dict(df, "emotion", "score")
 
     def test_df_to_categorical_dict_missing_value_column(self):
         u = make_util()
         df = pd.DataFrame({"emotion": ["happy", "sad"]})
-        with self.assertRaises(SystemExit):
+        with self.assertRaises(NkululukoError):
             u.df_to_categorical_dict(df, "emotion", "score")
 
     def test_is_dict_with_string_values_exception(self):

--- a/tests/utils/test_storage.py
+++ b/tests/utils/test_storage.py
@@ -5,6 +5,7 @@ import tempfile
 import unittest
 
 import nkululeko.glob_conf as glob_conf
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -180,7 +181,7 @@ class TestStorageMixin(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
             path = f.name
         try:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(NkululukoError):
                 u.write_store(df, path, "unknown")
         finally:
             if os.path.exists(path):
@@ -191,7 +192,7 @@ class TestStorageMixin(unittest.TestCase):
         with tempfile.NamedTemporaryFile(suffix=".txt", delete=False) as f:
             path = f.name
         try:
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(NkululukoError):
                 u.get_store(path, "unknown")
         finally:
             if os.path.exists(path):
@@ -229,16 +230,16 @@ class TestStorageMixin(unittest.TestCase):
         u = make_util()
         path = self._write_tmp("1.0 invalid 3.0\n")
         try:
-            # The function calls sys.exit() on error, so it raises SystemExit
-            with self.assertRaises(SystemExit):
+            # The function raises NkululukoError on error
+            with self.assertRaises(NkululukoError):
                 u.read_first_line_floats(path)
         finally:
             os.unlink(path)
 
     def test_read_first_line_floats_file_not_found(self):
         u = make_util()
-        # Should handle FileNotFoundError by calling sys.exit()
-        with self.assertRaises(SystemExit):
+        # Should handle FileNotFoundError by raising NkululukoError
+        with self.assertRaises(NkululukoError):
             u.read_first_line_floats("/nonexistent/file.txt")
 
     def test_read_first_line_floats_io_error(self):
@@ -247,7 +248,7 @@ class TestStorageMixin(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmpdir:
             path = os.path.join(tmpdir, "file.txt")
             os.mkdir(path)  # Make it a directory
-            with self.assertRaises(SystemExit):
+            with self.assertRaises(NkululukoError):
                 u.read_first_line_floats(path)
 
 

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -11,6 +11,7 @@ import pytest
 import audeer
 import nkululeko.glob_conf as glob_conf
 import nkululeko.utils.util as util_mod
+from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
 
 
@@ -153,6 +154,42 @@ class TestExpIsClassification:
         glob_conf.config["EXP"]["type"] = "regression"
         u = Util("test")
         assert u.exp_is_classification() is False
+
+
+# ---------------------------------------------------------------------------
+# error()
+# ---------------------------------------------------------------------------
+
+
+class TestError:
+    def test_raises_nkululuko_error_with_logger(self, caplog):
+        u = Util("mycaller")
+        with pytest.raises(NkululukoError, match="something went wrong"):
+            u.error("something went wrong")
+
+    def test_error_message_includes_caller_with_logger(self, caplog):
+        u = Util("mycaller")
+        with pytest.raises(NkululukoError) as exc_info:
+            u.error("bad input")
+        assert "mycaller" in str(exc_info.value)
+        assert "bad input" in str(exc_info.value)
+
+    def test_raises_nkululuko_error_without_logger(self, capsys):
+        u = Util("nocaller")
+        u.logger = None
+        with pytest.raises(NkululukoError, match="no logger path"):
+            u.error("no logger path")
+        captured = capsys.readouterr()
+        assert "no logger path" in captured.out
+        assert "nocaller" in captured.out
+
+    def test_print_path_uses_full_msg(self, capsys):
+        u = Util("caller")
+        u.logger = None
+        with pytest.raises(NkululukoError):
+            u.error("test message")
+        captured = capsys.readouterr()
+        assert "ERROR: caller: test message" in captured.out
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixing issue #[bagustris/36](https://github.com/bagustris/nkululeko/issues/36)

* Initial plan

* Replace sys.exit() in Util.error() with NkululukoError exception

Create nkululeko/utils/errors.py with NkululukoError(RuntimeError). Modify Util.error() to raise NkululukoError instead of calling sys.exit(). Update all CLI entry points (main() functions) to catch NkululukoError and call sys.exit(1), maintaining backward compatibility for CLI users. Update tests to expect NkululukoError instead of SystemExit.

* Address review feedback: remove unnecessary pass, remove unreachable DONE message

* Fix print path consistency and add Util.error() pytest coverage

* test: expect NkululukoError instead of SystemExit in modelrunner test

Util.error() now raises NkululukoError instead of calling sys.exit(), so test_unknown_model_raises must expect NkululukoError. This fixes the failing "Run pytest with coverage" check on PR #53.



* refactor(export): reduce main() cognitive complexity below SonarCloud limit

Extract the per-split file export loop into _process_split() and the destination-path construction into _export_file(), removing the nested loops and branches from main(). Drops main()'s cognitive complexity from 16 to within the allowed 15. Behaviour is unchanged.



---------