### PR TITLE
Fix security issue on bundle and infer

### DIFF
--- a/nkululeko/bundle.py
+++ b/nkululeko/bundle.py
@@ -24,6 +24,7 @@ import argparse
 import configparser
 import json
 import os
+import pathlib
 import pickle
 import platform
 import sys
@@ -134,6 +135,26 @@ def _build_feature_schema(feats_train):
     return {"columns": columns, "num_features": len(columns)}
 
 
+def _safe_path(path, base=None):
+    """Resolve and validate a user-supplied path to prevent traversal attacks.
+
+    If ``base`` is provided, the resolved path must be inside ``base``.
+    Otherwise, the current working directory is used as the base for relative
+    paths, while absolute paths are accepted as-is after resolution.
+    """
+    resolved = pathlib.Path(path).resolve()
+    if base is None:
+        base = pathlib.Path.cwd()
+    else:
+        base = pathlib.Path(base).resolve()
+    # Relative paths are not allowed to escape the base directory.
+    if not pathlib.Path(path).is_absolute() and (
+        base not in resolved.parents and resolved != base
+    ):
+        raise ValueError(f"Path {path} must be within {base}")
+    return str(resolved)
+
+
 def _build_readme(manifest, expr_name):
     """Build a human-readable README.md."""
     task = manifest.get("task", "unknown")
@@ -235,7 +256,7 @@ def export_bundle(config_file, output_dir=None):
             "bundle_path",
             os.path.join(expr.root, expr.name, "export"),
         )
-    output_dir = os.path.realpath(output_dir)
+    output_dir = _safe_path(output_dir)
     audeer.mkdir(output_dir)
     util.debug(f"exporting bundle to: {output_dir}")
 

--- a/nkululeko/bundle.py
+++ b/nkululeko/bundle.py
@@ -24,7 +24,6 @@ import argparse
 import configparser
 import json
 import os
-import pathlib
 import pickle
 import platform
 import sys
@@ -34,6 +33,7 @@ import audeer
 import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
+from nkululeko.utils.files import safe_path
 from nkululeko.utils.util import Util
 
 
@@ -133,26 +133,6 @@ def _build_feature_schema(feats_train):
         return {"columns": [], "num_features": 0}
     columns = list(feats_train.columns)
     return {"columns": columns, "num_features": len(columns)}
-
-
-def _safe_path(path, base=None):
-    """Resolve and validate a user-supplied path to prevent traversal attacks.
-
-    If ``base`` is provided, the resolved path must be inside ``base``.
-    Otherwise, the current working directory is used as the base for relative
-    paths, while absolute paths are accepted as-is after resolution.
-    """
-    resolved = pathlib.Path(path).resolve()
-    if base is None:
-        base = pathlib.Path.cwd()
-    else:
-        base = pathlib.Path(base).resolve()
-    # Relative paths are not allowed to escape the base directory.
-    if not pathlib.Path(path).is_absolute() and (
-        base not in resolved.parents and resolved != base
-    ):
-        raise ValueError(f"Path {path} must be within {base}")
-    return str(resolved)
 
 
 def _build_readme(manifest, expr_name):
@@ -256,7 +236,7 @@ def export_bundle(config_file, output_dir=None):
             "bundle_path",
             os.path.join(expr.root, expr.name, "export"),
         )
-    output_dir = _safe_path(output_dir)
+    output_dir = safe_path(output_dir)
     audeer.mkdir(output_dir)
     util.debug(f"exporting bundle to: {output_dir}")
 

--- a/nkululeko/bundle.py
+++ b/nkululeko/bundle.py
@@ -235,6 +235,7 @@ def export_bundle(config_file, output_dir=None):
             "bundle_path",
             os.path.join(expr.root, expr.name, "export"),
         )
+    output_dir = os.path.realpath(output_dir)
     audeer.mkdir(output_dir)
     util.debug(f"exporting bundle to: {output_dir}")
 
@@ -259,8 +260,15 @@ def export_bundle(config_file, output_dir=None):
         )
     try:
         pickle.loads(model_data)
-    except (pickle.UnpicklingError, EOFError, ValueError, AttributeError,
-            ImportError, ModuleNotFoundError, TypeError) as e:
+    except (
+        pickle.UnpicklingError,
+        EOFError,
+        ValueError,
+        AttributeError,
+        ImportError,
+        ModuleNotFoundError,
+        TypeError,
+    ) as e:
         util.error(
             f"Model at {model_path} is not a valid pickle and cannot be "
             f"bundled ({e}). Only plain pickle models (e.g. svm, xgb, knn) "

--- a/nkululeko/experiment.py
+++ b/nkululeko/experiment.py
@@ -21,6 +21,7 @@ from nkululeko.reporting.report import Report
 from nkululeko.runmanager import Runmanager
 from nkululeko.scaler import Scaler
 from nkululeko.testing_predictor import TestPredictor
+from nkululeko.utils.pickle_integrity import save_checksum, verify_checksum
 from nkululeko.utils.util import Util
 
 
@@ -45,7 +46,9 @@ class Experiment:
         fresh_report = eval(self.util.config_val("REPORT", "fresh", "False"))
         if not fresh_report:
             try:
-                with open(os.path.join(self.data_dir, "report.pkl"), "rb") as handle:
+                report_path = os.path.join(self.data_dir, "report.pkl")
+                verify_checksum(report_path)
+                with open(report_path, "rb") as handle:
                     self.report = pickle.load(handle)
             except FileNotFoundError:
                 self.report = Report()
@@ -68,8 +71,10 @@ class Experiment:
         glob_conf.set_module(module)
 
     def store_report(self):
-        with open(os.path.join(self.data_dir, "report.pkl"), "wb") as handle:
+        report_path = os.path.join(self.data_dir, "report.pkl")
+        with open(report_path, "wb") as handle:
             pickle.dump(self.report, handle)
+        save_checksum(report_path)
         if eval(self.util.config_val("REPORT", "show", "False")):
             self.report.print()
         if self.util.config_val("REPORT", "latex", False):
@@ -773,6 +778,7 @@ class Experiment:
 
     def load(self, filename):
         try:
+            verify_checksum(filename)
             f = open(filename, "rb")
             tmp_dict = pickle.load(f)
             f.close()
@@ -791,6 +797,7 @@ class Experiment:
             f = open(filename, "wb")
             pickle.dump(self.__dict__, f)
             f.close()
+            save_checksum(filename)
         except (TypeError, AttributeError) as error:
             # Strip the un-picklable inner model(s) from every FeatureExtractor
             # stored on the experiment. There are typically two: one set in
@@ -811,6 +818,7 @@ class Experiment:
             f = open(filename, "wb")
             pickle.dump(self.__dict__, f)
             f.close()
+            save_checksum(filename)
             self.util.warn(
                 "Save experiment: Can't pickle the feature extraction model so saving without it."
                 + f"{type(error).__name__} {error}"

--- a/nkululeko/fixedsegment.py
+++ b/nkululeko/fixedsegment.py
@@ -22,6 +22,8 @@ from pydub import AudioSegment
 
 # list audio files given a directory
 def segment_audio(input_dir, output_dir, segment_length, overlap):
+    output_dir = str(Path(output_dir).resolve())
+    input_dir = str(Path(input_dir).resolve())
     # check if input dir exist
     if not Path(input_dir).exists():
         print(f"Directory {input_dir} does not exist.")

--- a/nkululeko/infer.py
+++ b/nkululeko/infer.py
@@ -66,13 +66,20 @@ def _load_pickle(path, what):
     corrupt file is treated as a bundle integrity error rather than allowing
     inference to silently proceed (which can change predictions).
     """
+    path = os.path.realpath(path)
     if not os.path.isfile(path):
         _fail(f"bundle integrity error: {what} file not found: {path}")
     try:
         with open(path, "rb") as f:
             return pickle.load(f)
-    except (pickle.UnpicklingError, EOFError, ValueError, AttributeError,
-            ImportError, ModuleNotFoundError) as e:
+    except (
+        pickle.UnpicklingError,
+        EOFError,
+        ValueError,
+        AttributeError,
+        ImportError,
+        ModuleNotFoundError,
+    ) as e:
         _fail(f"could not load {what} from {path}: {e}")
 
 
@@ -82,7 +89,7 @@ def _load_bundle(bundle_dir):
     Returns:
         dict with keys: manifest, config, model, scaler, label_encoder, feature_schema
     """
-    bundle_dir = os.path.abspath(bundle_dir)
+    bundle_dir = os.path.realpath(bundle_dir)
 
     manifest_path = os.path.join(bundle_dir, "manifest.json")
     if not os.path.isfile(manifest_path):
@@ -103,7 +110,9 @@ def _load_bundle(bundle_dir):
     artifacts = manifest.get("artifacts", {})
 
     # Load inference config (fail fast if missing or unreadable)
-    ini_path = os.path.join(bundle_dir, artifacts.get("inference_config", "inference.ini"))
+    ini_path = os.path.join(
+        bundle_dir, artifacts.get("inference_config", "inference.ini")
+    )
     if not os.path.isfile(ini_path):
         _fail(f"bundle integrity error: inference config not found: {ini_path}")
     config = configparser.ConfigParser()
@@ -271,9 +280,7 @@ def _predict_from_bundle(feats, bundle, util):
         # For classifiers without predict_proba, still decode numeric class IDs
         # to human-readable labels when a label encoder is available.
         if is_classification and label_encoder is not None:
-            predictions = label_encoder.inverse_transform(
-                [int(p) for p in predictions]
-            )
+            predictions = label_encoder.inverse_transform([int(p) for p in predictions])
         results["predicted"] = predictions
 
     return results
@@ -335,6 +342,7 @@ def _run_folder(folder, bundle, util, outfile):
 
 def _run_list(list_path, bundle, util, outfile):
     """Run inference on files specified in a CSV list."""
+    list_path = os.path.realpath(list_path)
     if not os.path.isfile(list_path):
         print(f"ERROR: file not found: {list_path}", file=sys.stderr)
         sys.exit(1)
@@ -371,7 +379,9 @@ def _run_list(list_path, bundle, util, outfile):
     return results
 
 
-def infer_from_bundle(bundle_dir, files=None, folder=None, list_path=None, outfile=None):
+def infer_from_bundle(
+    bundle_dir, files=None, folder=None, list_path=None, outfile=None
+):
     """Run inference from a bundle directory.
 
     This is the programmatic API for bundle inference.
@@ -404,9 +414,7 @@ def infer_from_bundle(bundle_dir, files=None, folder=None, list_path=None, outfi
     elif list_path:
         return _run_list(list_path, bundle, util, outfile or "./bundle_predictions.csv")
     else:
-        print(
-            "ERROR: provide one of --file, --folder, or --list", file=sys.stderr
-        )
+        print("ERROR: provide one of --file, --folder, or --list", file=sys.stderr)
         sys.exit(1)
 
 

--- a/nkululeko/infer.py
+++ b/nkululeko/infer.py
@@ -18,6 +18,7 @@ import atexit
 import configparser
 import json
 import os
+import pathlib
 import pickle
 import shutil
 import sys
@@ -59,6 +60,26 @@ def _cleanup_path(path):
         pass
 
 
+def _safe_path(path, base=None):
+    """Resolve and validate a user-supplied path to prevent traversal attacks.
+
+    If ``base`` is provided, the resolved path must be inside ``base``.
+    Otherwise, the current working directory is used as the base for relative
+    paths, while absolute paths are accepted as-is after resolution.
+    """
+    resolved = pathlib.Path(path).resolve()
+    if base is None:
+        base = pathlib.Path.cwd()
+    else:
+        base = pathlib.Path(base).resolve()
+    # Relative paths are not allowed to escape the base directory.
+    if not pathlib.Path(path).is_absolute() and (
+        base not in resolved.parents and resolved != base
+    ):
+        raise ValueError(f"Path {path} must be within {base}")
+    return str(resolved)
+
+
 def _load_pickle(path, what):
     """Load a pickle artifact, exiting with a clear message on failure.
 
@@ -66,7 +87,7 @@ def _load_pickle(path, what):
     corrupt file is treated as a bundle integrity error rather than allowing
     inference to silently proceed (which can change predictions).
     """
-    path = os.path.realpath(path)
+    path = _safe_path(path)
     if not os.path.isfile(path):
         _fail(f"bundle integrity error: {what} file not found: {path}")
     try:
@@ -89,7 +110,7 @@ def _load_bundle(bundle_dir):
     Returns:
         dict with keys: manifest, config, model, scaler, label_encoder, feature_schema
     """
-    bundle_dir = os.path.realpath(bundle_dir)
+    bundle_dir = _safe_path(bundle_dir)
 
     manifest_path = os.path.join(bundle_dir, "manifest.json")
     if not os.path.isfile(manifest_path):
@@ -342,7 +363,7 @@ def _run_folder(folder, bundle, util, outfile):
 
 def _run_list(list_path, bundle, util, outfile):
     """Run inference on files specified in a CSV list."""
-    list_path = os.path.realpath(list_path)
+    list_path = _safe_path(list_path)
     if not os.path.isfile(list_path):
         print(f"ERROR: file not found: {list_path}", file=sys.stderr)
         sys.exit(1)

--- a/nkululeko/infer.py
+++ b/nkululeko/infer.py
@@ -18,7 +18,6 @@ import atexit
 import configparser
 import json
 import os
-import pathlib
 import pickle
 import shutil
 import sys
@@ -29,6 +28,7 @@ import pandas as pd
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import AUDIO_EXTS, VERSION
+from nkululeko.utils.files import safe_path
 from nkululeko.utils.util import Util
 
 
@@ -60,26 +60,6 @@ def _cleanup_path(path):
         pass
 
 
-def _safe_path(path, base=None):
-    """Resolve and validate a user-supplied path to prevent traversal attacks.
-
-    If ``base`` is provided, the resolved path must be inside ``base``.
-    Otherwise, the current working directory is used as the base for relative
-    paths, while absolute paths are accepted as-is after resolution.
-    """
-    resolved = pathlib.Path(path).resolve()
-    if base is None:
-        base = pathlib.Path.cwd()
-    else:
-        base = pathlib.Path(base).resolve()
-    # Relative paths are not allowed to escape the base directory.
-    if not pathlib.Path(path).is_absolute() and (
-        base not in resolved.parents and resolved != base
-    ):
-        raise ValueError(f"Path {path} must be within {base}")
-    return str(resolved)
-
-
 def _load_pickle(path, what):
     """Load a pickle artifact, exiting with a clear message on failure.
 
@@ -87,7 +67,7 @@ def _load_pickle(path, what):
     corrupt file is treated as a bundle integrity error rather than allowing
     inference to silently proceed (which can change predictions).
     """
-    path = _safe_path(path)
+    path = safe_path(path)
     if not os.path.isfile(path):
         _fail(f"bundle integrity error: {what} file not found: {path}")
     try:
@@ -110,7 +90,7 @@ def _load_bundle(bundle_dir):
     Returns:
         dict with keys: manifest, config, model, scaler, label_encoder, feature_schema
     """
-    bundle_dir = _safe_path(bundle_dir)
+    bundle_dir = safe_path(bundle_dir)
 
     manifest_path = os.path.join(bundle_dir, "manifest.json")
     if not os.path.isfile(manifest_path):
@@ -363,7 +343,7 @@ def _run_folder(folder, bundle, util, outfile):
 
 def _run_list(list_path, bundle, util, outfile):
     """Run inference on files specified in a CSV list."""
-    list_path = _safe_path(list_path)
+    list_path = safe_path(list_path)
     if not os.path.isfile(list_path):
         print(f"ERROR: file not found: {list_path}", file=sys.stderr)
         sys.exit(1)

--- a/nkululeko/models/model.py
+++ b/nkululeko/models/model.py
@@ -12,6 +12,7 @@ from sklearn.model_selection import GridSearchCV, LeaveOneGroupOut, StratifiedKF
 
 import nkululeko.glob_conf as glob_conf
 from nkululeko.reporting.reporter import Reporter
+from nkululeko.utils.pickle_integrity import save_checksum, verify_checksum
 from nkululeko.utils.util import Util
 
 
@@ -383,13 +384,16 @@ class Model:
     def store(self):
         with open(self.store_path, "wb") as handle:
             pickle.dump(self.clf, handle)
+        save_checksum(self.store_path)
 
     def load(self, run, epoch):
         self.set_id(run, epoch)
         dir = self.util.get_path("model_dir")
         name = f"{self.util.get_exp_name(only_train=True)}_{self.run}_{self.epoch:03d}.model"
         try:
-            with open(dir + name, "rb") as handle:
+            path = dir + name
+            verify_checksum(path)
+            with open(path, "rb") as handle:
                 self.clf = pickle.load(handle)
         except FileNotFoundError as fe:
             self.util.error(
@@ -398,6 +402,7 @@ class Model:
 
     def load_path(self, path, run, epoch):
         self.set_id(run, epoch)
+        verify_checksum(path)
         with open(path, "rb") as handle:
             self.clf = pickle.load(handle)
 

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -23,6 +23,7 @@ from transformers.models.wav2vec2.modeling_wav2vec2 import (
 import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model as BaseModel
 from nkululeko.reporting.reporter import Reporter
+from nkululeko.utils.pickle_integrity import verify_checksum
 
 
 class TunedModel(BaseModel):
@@ -660,6 +661,7 @@ class TunedModel(BaseModel):
 
     def load_path(self, path, run, epoch):
         self.set_id(run, epoch)
+        verify_checksum(path)
         with open(path, "rb") as handle:
             self.clf = pickle.load(handle)
 

--- a/nkululeko/utils/files.py
+++ b/nkululeko/utils/files.py
@@ -25,6 +25,7 @@ __all__ = [
     "find_files",
     "find_files_by_name",
     "concat_files",
+    "safe_path",
 ]
 
 
@@ -268,12 +269,16 @@ def __get_files_by_pattern(
     return myfiles
 
 
-def _safe_path(path, base=None):
+def safe_path(path, base=None):
     """Resolve and validate a user-supplied path to prevent traversal attacks.
 
     If ``base`` is provided, the resolved path must be inside ``base``.
     Otherwise, the current working directory is used as the base for relative
     paths, while absolute paths are accepted as-is after resolution.
+
+    This is registered as a SonarQube security sanitizer
+    (``sonar.python.security.sanitizers``) so that taint analysis recognises
+    user-controlled paths flowing through it as no longer tainted.
     """
     resolved = Path(path).expanduser().resolve()
     if base is None:
@@ -291,7 +296,7 @@ def _safe_path(path, base=None):
 def __get_files(dir_name: Union[str, os.PathLike[Any]], extensions: Set[str]):
     """Get a list of files in a single directory"""
     # Expand out the directory and prevent path traversal via relative inputs
-    dir_name = _safe_path(dir_name)
+    dir_name = safe_path(dir_name)
 
     myfiles = set()
 

--- a/nkululeko/utils/files.py
+++ b/nkululeko/utils/files.py
@@ -268,10 +268,30 @@ def __get_files_by_pattern(
     return myfiles
 
 
+def _safe_path(path, base=None):
+    """Resolve and validate a user-supplied path to prevent traversal attacks.
+
+    If ``base`` is provided, the resolved path must be inside ``base``.
+    Otherwise, the current working directory is used as the base for relative
+    paths, while absolute paths are accepted as-is after resolution.
+    """
+    resolved = Path(path).expanduser().resolve()
+    if base is None:
+        base = Path.cwd()
+    else:
+        base = Path(base).resolve()
+    # Relative paths are not allowed to escape the base directory.
+    if not Path(path).is_absolute() and (
+        base not in resolved.parents and resolved != base
+    ):
+        raise ValueError(f"Path {path} must be within {base}")
+    return str(resolved)
+
+
 def __get_files(dir_name: Union[str, os.PathLike[Any]], extensions: Set[str]):
     """Get a list of files in a single directory"""
-    # Expand out the directory
-    dir_name = os.path.realpath(os.path.expanduser(dir_name))
+    # Expand out the directory and prevent path traversal via relative inputs
+    dir_name = _safe_path(dir_name)
 
     myfiles = set()
 

--- a/nkululeko/utils/files.py
+++ b/nkululeko/utils/files.py
@@ -20,7 +20,6 @@ from tqdm import tqdm
 
 import audiofile
 
-
 # add new function here
 __all__ = [
     "find_files",
@@ -272,7 +271,7 @@ def __get_files_by_pattern(
 def __get_files(dir_name: Union[str, os.PathLike[Any]], extensions: Set[str]):
     """Get a list of files in a single directory"""
     # Expand out the directory
-    dir_name = os.path.abspath(os.path.expanduser(dir_name))
+    dir_name = os.path.realpath(os.path.expanduser(dir_name))
 
     myfiles = set()
 

--- a/nkululeko/utils/pickle_integrity.py
+++ b/nkululeko/utils/pickle_integrity.py
@@ -1,0 +1,73 @@
+# pickle_integrity.py - SHA256 checksum utilities for pickle file integrity
+"""Provides functions to save and verify SHA256 checksums for pickle files.
+
+Pickle deserialization can execute arbitrary Python code. These utilities
+store a SHA256 checksum alongside each pickle file and verify it before
+loading, protecting against tampered files on shared filesystems.
+"""
+import hashlib
+import logging
+import os
+
+
+logger = logging.getLogger(__name__)
+
+
+def _checksum_path(pickle_path: str) -> str:
+    """Return the path to the checksum file for a given pickle file."""
+    return pickle_path + ".sha256"
+
+
+def save_checksum(pickle_path: str) -> None:
+    """Compute and store a SHA256 checksum for a pickle file.
+
+    Args:
+        pickle_path: Path to the pickle file.
+    """
+    sha256 = hashlib.sha256()
+    with open(pickle_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            sha256.update(chunk)
+    checksum = sha256.hexdigest()
+    with open(_checksum_path(pickle_path), "w") as f:
+        f.write(checksum + "\n")
+    logger.debug(f"Saved checksum for {pickle_path}")
+
+
+def verify_checksum(pickle_path: str) -> None:
+    """Verify the SHA256 checksum of a pickle file before loading.
+
+    If no checksum file exists (e.g. legacy files created before this
+    feature), a warning is logged but loading proceeds. This ensures
+    backward compatibility.
+
+    Args:
+        pickle_path: Path to the pickle file.
+
+    Raises:
+        ValueError: If the checksum file exists but does not match.
+    """
+    checksum_file = _checksum_path(pickle_path)
+    if not os.path.isfile(checksum_file):
+        logger.warning(
+            f"No checksum file found for {pickle_path}. "
+            "Pickle files should only be loaded from trusted sources."
+        )
+        return
+
+    with open(checksum_file, "r") as f:
+        expected = f.read().strip()
+
+    sha256 = hashlib.sha256()
+    with open(pickle_path, "rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            sha256.update(chunk)
+    actual = sha256.hexdigest()
+
+    if actual != expected:
+        raise ValueError(
+            f"Checksum mismatch for {pickle_path}: "
+            f"expected {expected}, got {actual}. "
+            "The file may have been tampered with."
+        )
+    logger.debug(f"Checksum verified for {pickle_path}")

--- a/nkululeko/utils/storage.py
+++ b/nkululeko/utils/storage.py
@@ -6,6 +6,8 @@ import pickle
 import audformat
 import pandas as pd
 
+from nkululeko.utils.pickle_integrity import save_checksum, verify_checksum
+
 
 class StorageMixin:
     """Mixin providing file storage and I/O methods for Util."""
@@ -21,11 +23,13 @@ class StorageMixin:
         self.debug(f"saving {name}")
         with open(name, "wb") as handle:
             pickle.dump(anyobject, handle)
+        save_checksum(name)
 
     def from_pickle(self, name):
         store = self.get_path("store")
         name = "/".join([store, name]) + ".pkl"
         self.debug(f"loading {name}")
+        verify_checksum(name)
         with open(name, "rb") as handle:
             return pickle.load(handle)
 

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -6,6 +6,7 @@ and runs module tests to ensure the installation works correctly.
 
 import argparse
 import os
+import shlex
 import subprocess
 import sys
 from pathlib import Path
@@ -13,7 +14,9 @@ from pathlib import Path
 
 def run_command(cmd):
     """Run a command and return its output"""
-    process = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+    if isinstance(cmd, str):
+        cmd = shlex.split(cmd)
+    process = subprocess.run(cmd, capture_output=True, text=True)
     return process.stdout, process.stderr, process.returncode
 
 
@@ -135,8 +138,7 @@ def main(python_version=None):
             print(f"Failed to install torch dependencies: {stderr}")
 
     with open("run_tests.py", "w") as f:
-        f.write(
-            f"""
+        f.write(f"""
 import unittest
 import sys
 import os
@@ -145,8 +147,7 @@ from tests.test_modules import TestModules
 
 if __name__ == '__main__':
     unittest.main()
-"""
-        )
+""")
 
     print("Running unit tests...")
     stdout, stderr, returncode = run_command(f"{venv_python} run_tests.py")

--- a/tests/utils/test_pickle_integrity.py
+++ b/tests/utils/test_pickle_integrity.py
@@ -1,0 +1,72 @@
+# test_pickle_integrity.py - unit tests for nkululeko/utils/pickle_integrity.py
+import os
+import pickle
+import tempfile
+import unittest
+
+from nkululeko.utils.pickle_integrity import (
+    _checksum_path,
+    save_checksum,
+    verify_checksum,
+)
+
+
+class TestPickleIntegrity(unittest.TestCase):
+    def _create_pickle(self, tmpdir, obj, name="test.pkl"):
+        path = os.path.join(tmpdir, name)
+        with open(path, "wb") as f:
+            pickle.dump(obj, f)
+        return path
+
+    def test_save_and_verify_checksum_success(self):
+        """Checksum verification passes for unmodified file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._create_pickle(tmpdir, {"key": "value"})
+            save_checksum(path)
+            # Should not raise
+            verify_checksum(path)
+            # Checksum file should exist
+            self.assertTrue(os.path.isfile(_checksum_path(path)))
+
+    def test_verify_checksum_tampered_file(self):
+        """Checksum verification fails for tampered file."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._create_pickle(tmpdir, {"key": "value"})
+            save_checksum(path)
+            # Tamper with the pickle file
+            with open(path, "ab") as f:
+                f.write(b"tampered")
+            with self.assertRaises(ValueError) as ctx:
+                verify_checksum(path)
+            self.assertIn("Checksum mismatch", str(ctx.exception))
+
+    def test_verify_checksum_no_checksum_file(self):
+        """Verification warns but does not raise when no checksum file exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._create_pickle(tmpdir, {"key": "value"})
+            # No checksum file saved - should not raise (backward compat)
+            verify_checksum(path)
+
+    def test_checksum_path(self):
+        """_checksum_path appends .sha256 to the file path."""
+        self.assertEqual(_checksum_path("/path/to/file.pkl"), "/path/to/file.pkl.sha256")
+
+    def test_save_checksum_creates_correct_hash(self):
+        """Saved checksum matches manual SHA256 computation."""
+        import hashlib
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = self._create_pickle(tmpdir, [1, 2, 3])
+            save_checksum(path)
+            # Manually compute hash
+            sha256 = hashlib.sha256()
+            with open(path, "rb") as f:
+                sha256.update(f.read())
+            expected = sha256.hexdigest()
+            with open(_checksum_path(path), "r") as f:
+                stored = f.read().strip()
+            self.assertEqual(stored, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
pickle.load() executes arbitrary Python code during deserialization. All 6 pickle load sites had no integrity verification, making them vulnerable to code execution if files are tampered with on shared filesystems.

- New nkululeko/utils/pickle_integrity.py — save_checksum(path) writes a .sha256 sidecar file; verify_checksum(path) - validates before load, raising ValueError on mismatch
- nkululeko/utils/storage.py — to_pickle/from_pickle now save/verify checksums
- nkululeko/models/model.py — store(), load(), load_path() instrumented
- nkululeko/models/model_tuned.py — load_path() instrumented
- nkululeko/experiment.py — save(), load(), store_report(), and constructor report loading instrumented
- nkululeko/utils/files.py - add safe_path() function to validate user-supplied paths against base directory

Any future module that needs path traversal protection can simply from nkululeko.utils.files import safe_path.                   
