### PR TITLE
fix: improve unseen-label tests to exercise real fill_train_and_tests…

### DIFF
--- a/nkululeko/data/datasplitter.py
+++ b/nkululeko/data/datasplitter.py
@@ -164,15 +164,37 @@ class Datasplitter:
                 if self.df_test.is_labeled:
                     self.util.debug(f"Categories test: {test_cats}")
                 if not self.df_train.empty:
-                    self.df_test[self.target] = self.label_encoder.transform(
-                        self.df_test[self.target]
-                    )
+                    try:
+                        self.df_test[self.target] = self.label_encoder.transform(
+                            self.df_test[self.target]
+                        )
+                    except ValueError:
+                        test_labels = set(self.df_test[self.target].unique())
+                        train_labels = set(self.label_encoder.classes_)
+                        unseen = test_labels - train_labels
+                        self.util.error(
+                            f"Test set contains labels not seen in training: "
+                            f"{unseen}. Training labels are: {train_labels}. "
+                            f"Consider using a combined split strategy or "
+                            f"filtering unseen labels."
+                        )
             if self.split3 and not self.df_dev.empty:
                 self.util.debug(f"Categories dev: {dev_cats}")
                 if not self.df_train.empty:
-                    self.df_dev[self.target] = self.label_encoder.transform(
-                        self.df_dev[self.target]
-                    )
+                    try:
+                        self.df_dev[self.target] = self.label_encoder.transform(
+                            self.df_dev[self.target]
+                        )
+                    except ValueError:
+                        dev_labels = set(self.df_dev[self.target].unique())
+                        train_labels = set(self.label_encoder.classes_)
+                        unseen = dev_labels - train_labels
+                        self.util.error(
+                            f"Dev set contains labels not seen in training: "
+                            f"{unseen}. Training labels are: {train_labels}. "
+                            f"Consider using a combined split strategy or "
+                            f"filtering unseen labels."
+                        )
         if self.got_speaker:
             speakers_train = (
                 0

--- a/nkululeko/experiment.py
+++ b/nkululeko/experiment.py
@@ -195,9 +195,20 @@ class Experiment:
             self.df_test.got_speaker = self.got_speaker
             if encode:
                 self.df_test["class_label"] = self.df_test[self.target]
-                self.df_test[self.target] = self.label_encoder.transform(
-                    self.df_test[self.target]
-                )
+                try:
+                    self.df_test[self.target] = self.label_encoder.transform(
+                        self.df_test[self.target]
+                    )
+                except ValueError:
+                    test_labels = set(self.df_test[self.target].unique())
+                    train_labels = set(self.label_encoder.classes_)
+                    unseen = test_labels - train_labels
+                    self.util.error(
+                        f"Test set contains labels not seen in training: "
+                        f"{unseen}. Training labels are: {train_labels}. "
+                        f"Consider using a combined split strategy or "
+                        f"filtering unseen labels."
+                    )
                 self.df_test.to_csv(storage_test)
 
     def fill_train_and_tests(self):

--- a/tests/data/test_datasplitter.py
+++ b/tests/data/test_datasplitter.py
@@ -233,3 +233,130 @@ class TestFillTrainAndTestsEarlyReturn:
         result = ds.fill_train_and_tests()
         assert isinstance(result, tuple)
         assert len(result) == 2
+
+
+class TestUnseenLabelsError:
+    """Test that unseen labels in test/dev sets produce helpful error messages."""
+
+    _FLAGS = (
+        "is_labeled",
+        "is_test",
+        "is_train",
+        "is_val",
+        "got_gender",
+        "got_age",
+        "got_speaker",
+    )
+
+    @staticmethod
+    def _tag_df(df):
+        """Set the standard split flags on a DataFrame in-place."""
+        df.is_labeled = True
+        df.got_gender = False
+        df.got_speaker = False
+
+    def _make_util(self, tmp_path, errors):
+        """Return a mock Util with working copy_flags and error capturing."""
+        flags = self._FLAGS
+
+        class MockUtil:
+            def get_path(self, k):
+                return str(tmp_path) + "/"
+
+            def config_val(self, sec, key, default):
+                return default
+
+            def debug(self, m):
+                pass
+
+            def warn(self, m):
+                pass
+
+            def error(self, m):
+                errors.append(m)
+
+            def copy_flags(self, src, tgt):
+                for flag in flags:
+                    if hasattr(src, flag):
+                        setattr(tgt, flag, getattr(src, flag))
+
+            def exp_is_classification(self):
+                return True
+
+        return MockUtil()
+
+    def test_unseen_label_in_test_set(self, tmp_path):
+        """fill_train_and_tests emits a descriptive error when test labels are unseen."""
+        errors = []
+        tag = self._tag_df
+
+        class FakeDataset:
+            name = "fake_db"
+            is_labeled = True
+            got_gender = False
+            got_speaker = False
+
+            def split(self):
+                self.df_train = pd.DataFrame({"emotion": ["happy", "sad"]})
+                tag(self.df_train)
+                self.df_test = pd.DataFrame({"emotion": ["happy", "unknown"]})
+                tag(self.df_test)
+
+            def prepare_labels(self):
+                pass
+
+            df_train = pd.DataFrame()
+            df_test = pd.DataFrame()
+
+        ds = Datasplitter.__new__(Datasplitter)
+        ds.util = self._make_util(tmp_path, errors)
+        ds.target = "emotion"
+        ds.split3 = False
+        ds.got_speaker = False
+        ds.datasets = {"fake_db": FakeDataset()}
+
+        ds.fill_train_and_tests()
+
+        assert len(errors) == 1
+        assert "unknown" in errors[0]
+        assert "not seen in training" in errors[0]
+        assert "Training labels are" in errors[0]
+
+    def test_unseen_label_in_dev_set(self, tmp_path):
+        """fill_train_and_tests emits a descriptive error when dev labels are unseen."""
+        errors = []
+        tag = self._tag_df
+
+        class FakeDataset:
+            name = "fake_db"
+            is_labeled = True
+            got_gender = False
+            got_speaker = False
+
+            def split_3(self):
+                self.df_train = pd.DataFrame({"emotion": ["happy", "sad"]})
+                tag(self.df_train)
+                self.df_test = pd.DataFrame({"emotion": ["happy", "sad"]})
+                tag(self.df_test)
+                self.df_dev = pd.DataFrame({"emotion": ["happy", "novelcat"]})
+                tag(self.df_dev)
+
+            def prepare_labels(self):
+                pass
+
+            df_train = pd.DataFrame()
+            df_test = pd.DataFrame()
+            df_dev = pd.DataFrame()
+
+        ds = Datasplitter.__new__(Datasplitter)
+        ds.util = self._make_util(tmp_path, errors)
+        ds.target = "emotion"
+        ds.split3 = True
+        ds.got_speaker = False
+        ds.datasets = {"fake_db": FakeDataset()}
+
+        ds.fill_train_and_tests()
+
+        assert len(errors) == 1
+        assert "novelcat" in errors[0]
+        assert "not seen in training" in errors[0]


### PR DESCRIPTION

* fix: [wrap label_encoder.transform with helpful error for unseen labels](https://github.com/bagustris/nkululeko/issues/39)

When test or dev sets contain labels not present in the training set, scikit-learn's LabelEncoder raises a generic ValueError. This wraps the transform calls in datasplitter.py and experiment.py with try/except blocks that provide a descriptive error message listing the unseen labels and suggesting remediation steps.

* test: rewrite unseen-label tests to exercise fill_train_and_tests() directly

* test: extract _tag_df helper to reduce flag-assignment duplication

---------