### PR TITLE
Fix auto-detection silently overwriting user-configured experiment type

### DIFF
--- a/.github/workflows/py311_aud_csv.yml
+++ b/.github/workflows/py311_aud_csv.yml
@@ -1,6 +1,13 @@
 name: Run Nkululeko with Python 3.11 on RAVDESS+PRAAT+XGB 
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - main
+      - master
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test:

--- a/.github/workflows/py312.yml
+++ b/.github/workflows/py312.yml
@@ -1,6 +1,12 @@
 name: Test Installation Python 3.12
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test-install:

--- a/.github/workflows/py313.yml
+++ b/.github/workflows/py313.yml
@@ -1,6 +1,13 @@
 name: Test Installation Python 3.13
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: 
+      - main               
+      - master    
+      - develop
+  pull_request:
+    types: [opened, synchronize, reopened]
 
 jobs:
   test-install:

--- a/nkululeko/data/dataset.py
+++ b/nkululeko/data/dataset.py
@@ -141,6 +141,28 @@ class Dataset:
             glob_conf.report.add_item(ReportItem("Data", "Load report", r_string))
             glob_conf.report.initial = False
 
+    def _autodetect_experiment_type(self, df):
+        """Auto-detect the experiment type from the label column.
+
+        When the labels look numeric and no experiment type is configured
+        explicitly, set ``[EXP] type`` to ``regression``. When a non-regression
+        type is configured explicitly, respect it and emit a warning naming the
+        label column that triggered the detection, instead of silently
+        overwriting the user's configuration.
+        """
+        if not self.util.is_numeric(df[self.col_label]):
+            return
+        user_type = self.util.config_val("EXP", "type", None)
+        if user_type is None:
+            glob_conf.config["EXP"]["type"] = "regression"
+        elif user_type != "regression":
+            self.util.warn(
+                f"{self.name}: Configured [EXP] type={user_type} but label "
+                f"column '{self.col_label}' looks like regression. Respecting "
+                f"configured type. Verify your data or type configuration if "
+                f"this is unintended."
+            )
+
     def load(self):
         """Load the dataframe with files, speakers and task labels"""
         self.root = self._load_db()
@@ -163,8 +185,7 @@ class Dataset:
                     f"set 'DATA.target' or '{self.name}.label' in your configuration."
                 )
                 df = self.db.get(self.col_label, columns)
-                if self.util.is_numeric(df[self.col_label]):
-                    glob_conf.config["EXP"]["type"] = "regression"
+                self._autodetect_experiment_type(df)
             else:
                 df = pd.DataFrame(index=self.db.files)
         elif len(tables) > 0:

--- a/tests/data/test_dataset_autodetect.py
+++ b/tests/data/test_dataset_autodetect.py
@@ -1,0 +1,109 @@
+"""Tests for experiment-type auto-detection in nkululeko/data/dataset.py.
+
+Covers the ``Dataset._autodetect_experiment_type`` helper that was extracted
+from ``load()``: it must only set ``[EXP] type`` to ``regression`` when no
+type is configured, respect (and warn about) an explicit non-regression type,
+and do nothing for non-numeric labels.
+"""
+
+import configparser
+
+import pandas as pd
+import pytest
+from pandas.api.types import is_numeric_dtype
+
+import nkululeko.glob_conf as glob_conf
+from nkululeko.data.dataset import Dataset
+
+
+class _FakeUtil:
+    """Minimal Util stand-in: real is_numeric + config_val + warn capture."""
+
+    def __init__(self, config):
+        self.config = config
+        self.warnings = []
+
+    def is_numeric(self, series):
+        # Mirror the real Util.is_numeric (DataFrameMixin) behaviour.
+        return is_numeric_dtype(series)
+
+    def config_val(self, section, key, default):
+        if self.config is None:
+            return default
+        try:
+            return self.config[section][key]
+        except KeyError:
+            return default
+
+    def warn(self, message):
+        self.warnings.append(message)
+
+
+@pytest.fixture(autouse=True)
+def _reset_glob_conf():
+    """Ensure glob_conf is clean between tests and reset afterwards."""
+    glob_conf.config = None
+    yield
+    glob_conf.config = None
+
+
+def _make_dataset(config, col_label="age"):
+    """Create a bare Dataset wired to a fake util (no audformat db needed)."""
+    # The helper reads via self.util.config_val and writes via glob_conf.config,
+    # so both must reference the same configparser object (as in production).
+    glob_conf.config = config
+    ds = Dataset.__new__(Dataset)
+    ds.name = "test_db"
+    ds.col_label = col_label
+    ds.util = _FakeUtil(config)
+    return ds
+
+
+def _numeric_df():
+    return pd.DataFrame({"age": [23.0, 45.0, 60.0]})
+
+
+def _categorical_df():
+    return pd.DataFrame({"emotion": ["happy", "sad", "angry"]})
+
+
+class TestAutodetectExperimentType:
+    def test_sets_regression_when_no_type_configured(self):
+        config = configparser.ConfigParser()
+        config.add_section("EXP")
+        ds = _make_dataset(config)
+        ds._autodetect_experiment_type(_numeric_df())
+        assert glob_conf.config["EXP"]["type"] == "regression"
+        assert ds.util.warnings == []
+
+    def test_warns_and_respects_non_regression_type(self):
+        config = configparser.ConfigParser()
+        config.add_section("EXP")
+        config.set("EXP", "type", "classification")
+        ds = _make_dataset(config)
+        ds._autodetect_experiment_type(_numeric_df())
+        # User's configured type is respected, not overwritten.
+        assert glob_conf.config["EXP"]["type"] == "classification"
+        # A single warning is emitted that names the label column.
+        assert len(ds.util.warnings) == 1
+        msg = ds.util.warnings[0]
+        assert "age" in msg
+        assert "classification" in msg
+
+    def test_no_warn_when_regression_already_configured(self):
+        config = configparser.ConfigParser()
+        config.add_section("EXP")
+        config.set("EXP", "type", "regression")
+        ds = _make_dataset(config)
+        ds._autodetect_experiment_type(_numeric_df())
+        assert glob_conf.config["EXP"]["type"] == "regression"
+        assert ds.util.warnings == []
+
+    def test_no_change_for_non_numeric_labels(self):
+        config = configparser.ConfigParser()
+        config.add_section("EXP")
+        config.set("EXP", "type", "classification")
+        ds = _make_dataset(config, col_label="emotion")
+        ds._autodetect_experiment_type(_categorical_df())
+        assert glob_conf.config["EXP"]["type"] == "classification"
+        assert ds.util.warnings == []


### PR DESCRIPTION
Previously, auto-detection of numeric labels would silently overwrite the user's explicit [EXP] type setting to 'regression'. Now, auto-detection only sets the type when the user hasn't configured it explicitly, and emits a warning when there's a conflict between the configured type and the detected data type.
* fix: respect user-configured experiment type, only auto-detect when not set
* fix: improve warning message for type mismatch clarity
* fix: comment from sourcery (add warning and test)