### PR TITLE
Fix logger handler race condition with threading lock in Util (#58)

### DIFF
--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -6,6 +6,7 @@ import logging
 import os.path
 import shutil
 import sys
+import threading
 
 from pathlib import Path
 
@@ -16,6 +17,8 @@ from nkululeko.utils.dataframe import DataFrameMixin
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.naming import NamingMixin
 from nkululeko.utils.storage import StorageMixin
+
+_log_lock = threading.Lock()
 
 
 class _MessageOnlyFormatter(logging.Formatter):
@@ -97,24 +100,31 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         # Only add a console handler if this logger has none yet.
         # Use logger.handlers (direct handlers) rather than hasHandlers()
         # so the check is scoped to this logger only, not the full hierarchy.
-        if not logger.handlers:
-            console_handler = logging.StreamHandler()
-            console_handler.setFormatter(formatter)
-            logger.addHandler(console_handler)
+        # _log_lock makes the check-then-act atomic so concurrent
+        # threads/instances can't both pass the check and add a handler each.
+        with _log_lock:
+            if not logger.handlers:
+                console_handler = logging.StreamHandler()
+                console_handler.setFormatter(formatter)
+                logger.addHandler(console_handler)
 
     def _setup_file_logging(self, logger, formatter):
         try:
             root = self.config["EXP"]["root"]
             name = self.config["EXP"]["name"]
             log_dir, log_file, timestamp = self._build_log_path(root, name)
-            self._remove_stale_file_handlers(logger, log_dir)
 
-            if self._has_file_handler(logger):
-                return
+            # Only the handler check-then-act is locked; the filesystem work
+            # above (mkdir) and the config snapshot copy below stay outside
+            # the critical section so unrelated threads aren't blocked on I/O.
+            with _log_lock:
+                self._remove_stale_file_handlers(logger, log_dir)
+                if self._has_file_handler(logger):
+                    return
+                file_handler = logging.FileHandler(log_file)
+                file_handler.setFormatter(formatter)
+                logger.addHandler(file_handler)
 
-            file_handler = logging.FileHandler(log_file)
-            file_handler.setFormatter(formatter)
-            logger.addHandler(file_handler)
             self._copy_config_snapshot(log_dir, name, timestamp)
         except KeyError:
             logger.debug("File logging skipped: EXP configuration (root/name) incomplete")
@@ -125,6 +135,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
     def _build_log_path(root, name):
         log_dir = os.path.abspath(os.path.join(root, name, "log"))
         audeer.mkdir(log_dir)
+        # Include seconds to avoid filename collisions between close-together runs
         timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
         return log_dir, os.path.join(log_dir, f"{name}_{timestamp}.log"), timestamp
 

--- a/tests/utils/test_util.py
+++ b/tests/utils/test_util.py
@@ -3,6 +3,7 @@
 import configparser
 import logging
 import os
+import threading
 
 import numpy as np
 import pandas as pd
@@ -344,6 +345,53 @@ class TestSetupLogging:
             h for h in logger.handlers if isinstance(h, logging.FileHandler)
         ]
         assert len(file_handlers) == 0
+
+    def test_no_duplicate_handlers_under_concurrent_access(self, tmp_path):
+        """Concurrent Util creation should not produce duplicate handlers.
+
+        setup_method/teardown_method reset the shared logger before and after
+        this test, so it starts from a known-empty handler list regardless of
+        what other tests in this run have done.
+        """
+        glob_conf.config["EXP"]["root"] = str(tmp_path)
+        glob_conf.config["EXP"]["name"] = "concurrent_test"
+
+        logger = logging.getLogger(util_mod.__name__)
+        barrier = threading.Barrier(10)
+        errors = []
+
+        def create_util():
+            try:
+                # Synchronize threads to maximize the chance of exercising the race
+                barrier.wait()
+                Util("test")
+            except Exception as exc:  # pragma: no cover - defensive
+                errors.append(exc)
+
+        threads = [threading.Thread(target=create_util) for _ in range(10)]
+
+        for thread in threads:
+            thread.start()
+
+        for thread in threads:
+            thread.join()
+
+        # Ensure no thread failed
+        assert not errors
+
+        console_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler)
+            and not isinstance(h, logging.FileHandler)
+        ]
+        file_handlers = [
+            h for h in logger.handlers if isinstance(h, logging.FileHandler)
+        ]
+
+        # The race being tested affects both console and file handlers.
+        assert len(console_handlers) == 1
+        assert len(file_handlers) == 1
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Fix logger handler race condition with threading lock in Util

Add a module-level threading lock to protect the check-then-act pattern in setup_logging(), preventing duplicate handler creation when multiple threads or Util instances concurrently configure the same logger.

Fixes: Logger handler race condition and potential handler leak

* Modified util.py
* Update test_util.py

---------