### PR TITLE
Fix  Incomplete model/experiment type compatibility, eliminate code duplication, etc.

### DIFF
--- a/nkululeko/data/dataset.py
+++ b/nkululeko/data/dataset.py
@@ -4,16 +4,16 @@ import os
 import os.path
 from random import sample
 
+import audformat
 import numpy as np
 import pandas as pd
-import audformat
 
-from nkululeko.filter_data import DataFilter
 import nkululeko.glob_conf as glob_conf
+from nkululeko.constants import COL_AGE, COL_SEX, COL_SPEAKER
+from nkululeko.filter_data import DataFilter
 from nkululeko.plots import Plots
 from nkululeko.reporting.report_item import ReportItem
 from nkululeko.utils.util import Util
-from nkululeko.constants import COL_AGE, COL_SEX, COL_SPEAKER
 
 
 class Dataset:
@@ -33,15 +33,6 @@ class Dataset:
         self.target = self.util.config_val("DATA", "target", None)
         self.plot = Plots()
         self.limit = int(self.util.config_val_data(self.name, "limit", 0))
-        self.target_tables_append = eval(
-            self.util.config_val_data(self.name, "target_tables_append", "False")
-        )
-        if self.target_tables_append:
-            self.util.warn(
-                f"{self.name}: 'target_tables_append' is no longer supported "
-                "and has no effect. Tables are now merged automatically via "
-                "audformat db.get(). Please remove it from your config."
-            )
         self.start_fresh = eval(self.util.config_val("DATA", "no_reuse", "False"))
         self.is_labeled, self.got_speaker, self.got_gender, self.got_age = (
             False,
@@ -90,7 +81,6 @@ class Dataset:
                     if col_dict[key] == target:
                         return key
         return target
-            
 
     def _check_cols(self, df):
         rename_cols = self.util.config_val_data(self.name, "colnames", False)
@@ -502,8 +492,8 @@ class Dataset:
 
         from splitutils import (
             binning,
-            optimize_traintest_split,
             optimize_traindevtest_split,
+            optimize_traintest_split,
         )
 
         seed = 42

--- a/nkululeko/data/datasplitter.py
+++ b/nkululeko/data/datasplitter.py
@@ -2,14 +2,15 @@
 import ast
 import os
 import os.path
+import pickle
+import secrets
 
 import pandas as pd
-import secrets
 from sklearn.preprocessing import LabelEncoder
-import pickle
-from nkululeko.filter_data import DataFilter
+
 import nkululeko.glob_conf as glob_conf
 from nkululeko.file_checker import FileChecker
+from nkululeko.filter_data import DataFilter
 from nkululeko.utils.util import Util
 
 
@@ -41,6 +42,25 @@ class Datasplitter:
             )
         return df
 
+    def _encode_labels_safe(self, df, split_name):
+        """Encode labels in df using the fitted label encoder.
+
+        Emits a helpful error if df contains labels unseen during training.
+        """
+        try:
+            df[self.target] = self.label_encoder.transform(df[self.target])
+        except ValueError:
+            # Drop NaNs: missing labels aren't real classes and would break
+            # sorted() below when mixed with string class labels.
+            split_labels = set(df[self.target].dropna().unique())
+            train_labels = set(self.label_encoder.classes_)
+            unseen = sorted(split_labels - train_labels)
+            self.util.error(
+                f"{split_name} set contains labels not seen in training: {unseen}. "
+                f"Training labels are: {sorted(train_labels)}. "
+                "Consider using a combined split strategy or filtering unseen labels."
+            )
+
     def _add_random_target(self, df):
         labels = glob_conf.labels
         a = [None] * len(df)
@@ -51,16 +71,10 @@ class Datasplitter:
 
     def fill_train_and_tests(self):
         """Set up train and development sets. The method should be specified in the config."""
-        self.df_train, self.df_test, self.df_dev = (
-            pd.DataFrame(),
-            pd.DataFrame(),
-            pd.DataFrame(),
-        )
-        if self.split3:
-            self.df_dev = pd.DataFrame()
-        else:
-            self.df_dev = None
-        for d in self.datasets.values():
+        self.df_dev = None
+        train_dfs, test_dfs, dev_dfs = [], [], []
+        all_datasets = list(self.datasets.values())
+        for d in all_datasets:
             if self.split3:
                 d.split_3()
             else:
@@ -71,19 +85,37 @@ class Datasplitter:
             if d.df_train.shape[0] == 0:
                 self.util.debug(f"warn: {d.name} train empty")
             else:
-                self.df_train = pd.concat([self.df_train, d.df_train])
-                self.util.copy_flags(d, self.df_train)
+                train_dfs.append(d.df_train)
             if d.df_test.shape[0] == 0:
                 self.util.debug(f"warn: {d.name} test empty")
             else:
-                self.df_test = pd.concat([self.df_test, d.df_test])
-                self.util.copy_flags(d, self.df_test)
+                test_dfs.append(d.df_test)
             if self.split3:
                 if d.df_dev.shape[0] == 0:
                     self.util.debug(f"warn: {d.name} dev empty")
                 else:
-                    self.df_dev = pd.concat([self.df_dev, d.df_dev])
-                    self.util.copy_flags(d, self.df_dev)
+                    dev_dfs.append(d.df_dev)
+
+        self.df_train = pd.concat(train_dfs) if train_dfs else pd.DataFrame()
+        self.df_test = pd.concat(test_dfs) if test_dfs else pd.DataFrame()
+        if self.split3:
+            self.df_dev = pd.concat(dev_dfs) if dev_dfs else pd.DataFrame()
+
+        # Aggregate boolean flags across all datasets (any-wins semantics):
+        # a combined DataFrame is labeled / has speaker / gender / age if ANY
+        # contributing dataset has that attribute set.
+        # NOTE: self.{flag} must be updated here so that the subsequent
+        # copy_flags(self, ...) calls propagate the correctly aggregated values
+        # onto each split DataFrame.
+        if all_datasets:
+            active_splits = [self.df_train, self.df_test]
+            if self.split3:
+                active_splits.append(self.df_dev)
+            for flag in ("is_labeled", "got_gender", "got_age", "got_speaker"):
+                aggregated = any(getattr(d, flag, False) for d in all_datasets)
+                setattr(self, flag, aggregated)
+                for split_df in active_splits:
+                    setattr(split_df, flag, aggregated)
 
         # Return early for unlabeled/unsupervised runs, but still return the split dataframes
         if self.target is None or self.target == "none":
@@ -164,37 +196,11 @@ class Datasplitter:
                 if self.df_test.is_labeled:
                     self.util.debug(f"Categories test: {test_cats}")
                 if not self.df_train.empty:
-                    try:
-                        self.df_test[self.target] = self.label_encoder.transform(
-                            self.df_test[self.target]
-                        )
-                    except ValueError:
-                        test_labels = set(self.df_test[self.target].unique())
-                        train_labels = set(self.label_encoder.classes_)
-                        unseen = test_labels - train_labels
-                        self.util.error(
-                            f"Test set contains labels not seen in training: "
-                            f"{unseen}. Training labels are: {train_labels}. "
-                            f"Consider using a combined split strategy or "
-                            f"filtering unseen labels."
-                        )
+                    self._encode_labels_safe(self.df_test, "Test")
             if self.split3 and not self.df_dev.empty:
                 self.util.debug(f"Categories dev: {dev_cats}")
                 if not self.df_train.empty:
-                    try:
-                        self.df_dev[self.target] = self.label_encoder.transform(
-                            self.df_dev[self.target]
-                        )
-                    except ValueError:
-                        dev_labels = set(self.df_dev[self.target].unique())
-                        train_labels = set(self.label_encoder.classes_)
-                        unseen = dev_labels - train_labels
-                        self.util.error(
-                            f"Dev set contains labels not seen in training: "
-                            f"{unseen}. Training labels are: {train_labels}. "
-                            f"Consider using a combined split strategy or "
-                            f"filtering unseen labels."
-                        )
+                    self._encode_labels_safe(self.df_dev, "Dev")
         if self.got_speaker:
             speakers_train = (
                 0

--- a/nkululeko/modelrunner.py
+++ b/nkululeko/modelrunner.py
@@ -3,8 +3,72 @@
 import ast
 
 from nkululeko import glob_conf
-from nkululeko.utils.util import Util
 from nkululeko.balance import DataBalancer
+from nkululeko.utils.util import Util
+
+# Fallback type-based heuristics used when a model instance is not yet available
+# or when the model does not declare explicit is_classifier / is_regressor flags.
+# Model types that only support classification
+CLASSIFIER_TYPES = frozenset(
+    {"svm", "xgb", "bayes", "gmm", "knn", "tree", "cnn", "mlp", "adm"}
+)
+# Model types that only support regression
+REGRESSOR_TYPES = frozenset({"svr", "xgr", "knn_reg", "lin_reg", "tree_reg", "mlp_reg"})
+
+
+def validate_model_task_support(model_type: str, task: str, model=None) -> None:
+    """Ensure model_type is compatible with the requested task.
+
+    When a model instance is provided its own capability flags
+    (``is_classifier`` / ``is_regressor``) take precedence over the
+    type-based allow-lists.  This lets future model implementations declare
+    their own capabilities without touching these sets.
+
+    :param model_type: model type string (e.g. ``'svm'``, ``'svr'``)
+    :param task: ``'classification'`` or ``'regression'``
+    :param model: optional instantiated model; checked for
+        ``is_classifier`` / ``is_regressor`` attributes when provided
+    """
+    util = Util("modelrunner")
+    is_classifier = getattr(model, "is_classifier", None) if model is not None else None
+    is_regressor = getattr(model, "is_regressor", None) if model is not None else None
+
+    if task == "classification":
+        _check_task_capability(
+            util, model_type, task, is_classifier, "regressor", REGRESSOR_TYPES
+        )
+    elif task == "regression":
+        _check_task_capability(
+            util, model_type, task, is_regressor, "classifier", CLASSIFIER_TYPES
+        )
+
+
+def _check_task_capability(
+    util, model_type, task, capability, opposite_label, forbidden_types
+) -> None:
+    """Validate a single task direction using capability flag or type fallback.
+
+    :param util: Util instance used to report errors.
+    :param model_type: model type string (e.g. ``'svm'``, ``'svr'``).
+    :param task: ``'classification'`` or ``'regression'``.
+    :param capability: the model's capability flag for this task
+        (``is_classifier`` or ``is_regressor``); ``None`` when not declared.
+    :param opposite_label: label of the opposite task (``'regressor'`` or
+        ``'classifier'``) used in the fallback error message.
+    :param forbidden_types: frozenset of model types that only support the
+        opposite task.
+    """
+    # Explicit negative capability flag is a hard error.
+    if capability is False:
+        util.error(f"Model '{model_type}' does not support {task}.")
+    # Explicit positive flag short-circuits the type-based fallback.
+    if capability is True:
+        return
+    # Fall back to type-set heuristics for models without capability flags.
+    if model_type in forbidden_types:
+        util.error(
+            f"Model '{model_type}' is a {opposite_label} but experiment type is {task}"
+        )
 
 
 class Modelrunner:
@@ -187,6 +251,10 @@ class Modelrunner:
         self._check_balancing()
         self._check_feature_balancing()
 
+        # Validate model/experiment type compatibility before instantiation
+        task = "classification" if self.util.exp_is_classification() else "regression"
+        validate_model_task_support(model_type, task)
+
         if model_type == "svm":
             from nkululeko.models.model_svm import SVM_model
 
@@ -285,11 +353,10 @@ class Modelrunner:
             )
         else:
             self.util.error(f"unknown model type: '{model_type}'")
-        if self.util.exp_is_classification() and not self.model.is_classifier:
-            self.util.error(
-                "Experiment type set to classification but model type is not a"
-                " classifier"
-            )
+        # Re-validate using the instantiated model's own capability flags so
+        # that models declaring is_classifier/is_regressor are honored even
+        # when their model_type is absent from the legacy type allow-lists.
+        validate_model_task_support(model_type, task, model=self.model)
         return self.model
 
     def _check_feature_balancing(self):

--- a/tests/data/test_datasplitter.py
+++ b/tests/data/test_datasplitter.py
@@ -2,6 +2,7 @@
 
 import configparser
 from datetime import timedelta
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -17,6 +18,23 @@ def _make_segmented_index(files):
         [timedelta(seconds=1)] * len(files),
     ]
     return pd.MultiIndex.from_arrays(arrays, names=["file", "start", "end"])
+
+
+def _tag_df(df):
+    """Set standard boolean flags to False on a split DataFrame."""
+    df.is_labeled = False
+    df.got_gender = False
+    df.got_speaker = False
+    return df
+
+
+def _make_fake_util(tmp_path):
+    """Return a minimal no-op utility stub for Datasplitter tests."""
+    util = MagicMock()
+    util.get_path.return_value = str(tmp_path) + "/"
+    util.config_val.side_effect = lambda sec, key, default: default
+    util.exp_is_classification.return_value = False
+    return util
 
 
 @pytest.fixture(autouse=True)
@@ -186,20 +204,208 @@ class TestBuildTestDsDf:
         assert len(ds.test_ds_df["db_b"]) == 1
 
 
+class TestLabelEncoderUnseenLabels:
+    """Verify fill_train_and_tests surfaces helpful errors for unseen labels."""
+
+    class _FakeDataset:
+        """Minimal dataset stub with pre-built splits."""
+
+        is_labeled = True
+        got_gender = False
+        got_age = False
+        got_speaker = False
+        name = "fake_db"
+
+        def __init__(self, train_labels, test_labels, dev_labels=None):
+            idx_tr = _make_segmented_index(
+                [f"/data/tr_{i}.wav" for i in range(len(train_labels))]
+            )
+            idx_te = _make_segmented_index(
+                [f"/data/te_{i}.wav" for i in range(len(test_labels))]
+            )
+            self.df_train = _tag_df(
+                pd.DataFrame({"emotion": train_labels}, index=idx_tr)
+            )
+            self.df_test = _tag_df(pd.DataFrame({"emotion": test_labels}, index=idx_te))
+            self.df_train.is_labeled = True
+            self.df_test.is_labeled = True
+            if dev_labels is not None:
+                idx_dev = _make_segmented_index(
+                    [f"/data/dev_{i}.wav" for i in range(len(dev_labels))]
+                )
+                self.df_dev = _tag_df(
+                    pd.DataFrame({"emotion": dev_labels}, index=idx_dev)
+                )
+                self.df_dev.is_labeled = True
+
+        def split(self):
+            pass
+
+        def split_3(self):
+            pass
+
+        def prepare_labels(self):
+            pass
+
+    def _make_ds(self, datasets, split3=False):
+        """Build a Datasplitter with real Util whose error() is captured."""
+        from nkululeko.utils.util import Util
+
+        ds = Datasplitter.__new__(Datasplitter)
+        ds.util = Util("datasplitter")
+        errors = []
+        ds.util.error = lambda m: errors.append(m)
+        ds.target = "emotion"
+        ds.split3 = split3
+        ds.got_speaker = False
+        ds.datasets = datasets
+        return ds, errors
+
+    def test_unseen_test_labels_calls_util_error(self):
+        """fill_train_and_tests should report labels in test split not seen in training."""
+        fake_ds = self._FakeDataset(
+            train_labels=["happy", "sad"],
+            test_labels=["angry"],
+        )
+        ds, errors = self._make_ds({"db": fake_ds})
+
+        ds.fill_train_and_tests()
+
+        assert len(errors) == 1
+        assert "angry" in errors[0]
+        assert "not seen in training" in errors[0]
+
+    def test_unseen_dev_labels_calls_util_error(self):
+        """fill_train_and_tests should report unseen dev-split labels when split3=True."""
+        fake_ds = self._FakeDataset(
+            train_labels=["happy", "sad"],
+            test_labels=["happy"],  # no unseen in test
+            dev_labels=["angry"],  # unseen in dev
+        )
+        ds, errors = self._make_ds({"db": fake_ds}, split3=True)
+
+        ds.fill_train_and_tests()
+
+        assert len(errors) == 1
+        assert "angry" in errors[0]
+        assert "not seen in training" in errors[0]
+
+    def test_unseen_test_labels_with_nan_does_not_crash(self):
+        """A partially-labeled test split (containing NaN) must not raise TypeError."""
+        fake_ds = self._FakeDataset(
+            train_labels=["happy", "sad"],
+            test_labels=["angry", float("nan")],
+        )
+        ds, errors = self._make_ds({"db": fake_ds})
+
+        ds.fill_train_and_tests()
+
+        assert len(errors) == 1
+        assert "angry" in errors[0]
+        assert "nan" not in errors[0]
+
+
+class TestFillTrainAndTestsConcatenation:
+    def test_multiple_datasets_concatenated_correctly(self, tmp_path, monkeypatch):
+        """fill_train_and_tests should concat all datasets without O(n²) intermediate copies."""
+
+        class FakeDataset:
+            def __init__(self, name, train_files, test_files):
+                self.name = name
+                idx_tr = _make_segmented_index(train_files)
+                idx_te = _make_segmented_index(test_files)
+                self.df_train = _tag_df(pd.DataFrame(index=idx_tr))
+                self.df_test = _tag_df(pd.DataFrame(index=idx_te))
+
+            def split(self):
+                pass  # already split in __init__
+
+            def prepare_labels(self):
+                pass
+
+        monkeypatch.setitem(glob_conf.config["DATA"], "target", "none")
+        monkeypatch.setattr(glob_conf, "target", None)
+
+        ds_a = FakeDataset("a", ["/a/tr_1.wav", "/a/tr_2.wav"], ["/a/te_1.wav"])
+        ds_b = FakeDataset("b", ["/b/tr_1.wav"], ["/b/te_1.wav", "/b/te_2.wav"])
+
+        ds = Datasplitter.__new__(Datasplitter)
+        ds.util = _make_fake_util(tmp_path)
+        ds.target = None
+        ds.split3 = False
+        ds.got_speaker = False
+        ds.datasets = {"a": ds_a, "b": ds_b}
+
+        df_train, df_test = ds.fill_train_and_tests()
+        assert len(df_train) == 3  # 2 from a + 1 from b
+        assert len(df_test) == 3  # 1 from a + 2 from b
+
+    def test_flag_aggregation_any_wins_on_self_and_splits(self, tmp_path, monkeypatch):
+        """Flags should be any-wins aggregated onto self and every split DataFrame."""
+
+        class FakeDataset:
+            def __init__(self, name, train_files, test_files, **flags):
+                self.name = name
+                idx_tr = _make_segmented_index(train_files)
+                idx_te = _make_segmented_index(test_files)
+                self.df_train = _tag_df(pd.DataFrame(index=idx_tr))
+                self.df_test = _tag_df(pd.DataFrame(index=idx_te))
+                for flag, value in flags.items():
+                    setattr(self, flag, value)
+
+            def split(self):
+                pass  # already split in __init__
+
+            def prepare_labels(self):
+                pass
+
+        monkeypatch.setitem(glob_conf.config["DATA"], "target", "none")
+        monkeypatch.setattr(glob_conf, "target", None)
+
+        # ds_a has every flag False, ds_b has every flag True: any-wins means
+        # the aggregated result must be True on self and every split.
+        ds_a = FakeDataset(
+            "a",
+            ["/a/tr_1.wav"],
+            ["/a/te_1.wav"],
+            is_labeled=False,
+            got_gender=False,
+            got_age=False,
+            got_speaker=False,
+        )
+        ds_b = FakeDataset(
+            "b",
+            ["/b/tr_1.wav"],
+            ["/b/te_1.wav"],
+            is_labeled=True,
+            got_gender=True,
+            got_age=True,
+            got_speaker=True,
+        )
+
+        ds = Datasplitter.__new__(Datasplitter)
+        ds.util = _make_fake_util(tmp_path)
+        ds.target = None
+        ds.split3 = False
+        ds.got_speaker = False
+        ds.datasets = {"a": ds_a, "b": ds_b}
+
+        df_train, df_test = ds.fill_train_and_tests()
+
+        for flag in ("is_labeled", "got_gender", "got_age", "got_speaker"):
+            assert getattr(ds, flag) is True
+            assert getattr(df_train, flag) is True
+            assert getattr(df_test, flag) is True
+
+
 class TestFillTrainAndTestsEarlyReturn:
-    def test_unsupervised_returns_splits_without_labels(self, tmp_path):
+    def test_unsupervised_returns_splits_without_labels(self, tmp_path, monkeypatch):
         """fill_train_and_tests returns (df_train, df_test) even when target is None."""
 
         class FakeDataset:
             def split(self):
-                self.df_train = pd.DataFrame(index=range(2))
-                self.df_test = pd.DataFrame(index=range(1))
-                self.df_train.is_labeled = False
-                self.df_test.is_labeled = False
-                self.df_train.got_gender = False
-                self.df_test.got_gender = False
-                self.df_train.got_speaker = False
-                self.df_test.got_speaker = False
+                self.df_train = _tag_df(pd.DataFrame(index=range(2)))
+                self.df_test = _tag_df(pd.DataFrame(index=range(1)))
 
             def prepare_labels(self):
                 pass  # no-op: unsupervised run has no labels to encode
@@ -208,23 +414,12 @@ class TestFillTrainAndTestsEarlyReturn:
             df_test = pd.DataFrame()
             name = "fake"
 
-        glob_conf.config["DATA"]["target"] = "none"
-        glob_conf.target = None
+        monkeypatch.setitem(glob_conf.config["DATA"], "target", "none")
+        monkeypatch.setattr(glob_conf, "target", None)
 
         fake_ds = FakeDataset()
         ds = Datasplitter.__new__(Datasplitter)
-        ds.util = type(
-            "U",
-            (),
-            {
-                "get_path": lambda self, k: str(tmp_path) + "/",
-                "config_val": lambda self, sec, key, default: default,
-                "debug": lambda self, m: None,
-                "warn": lambda self, m: None,
-                "copy_flags": lambda self, src, tgt: None,
-                "exp_is_classification": lambda self: False,
-            },
-        )()
+        ds.util = _make_fake_util(tmp_path)
         ds.target = None
         ds.split3 = False
         ds.got_speaker = False

--- a/tests/feat_extract/test_featureset.py
+++ b/tests/feat_extract/test_featureset.py
@@ -308,6 +308,28 @@ class TestExtractEmbeddingsWithErrorHandling:
         ]
         assert len(summary_calls) == 1
 
+    def test_keyboard_interrupt_not_swallowed(self, multiindex_featureset):
+        """KeyboardInterrupt must propagate through the extraction loop."""
+
+        def extract_fn_interrupt(file, start, end):
+            raise KeyboardInterrupt()
+
+        with pytest.raises(KeyboardInterrupt):
+            multiindex_featureset._extract_embeddings_with_error_handling(
+                extract_fn_interrupt
+            )
+
+    def test_type_error_not_swallowed(self, multiindex_featureset):
+        """TypeError (programming error) must propagate, not be silently swallowed."""
+
+        def extract_fn_type_error(file, start, end):
+            raise TypeError("unexpected argument")
+
+        with pytest.raises(TypeError):
+            multiindex_featureset._extract_embeddings_with_error_handling(
+                extract_fn_type_error
+            )
+
     def test_embedding_values_correct(self, multiindex_featureset, multiindex_data_df):
         """Embeddings returned by extract_fn appear as rows in the result DataFrame."""
         rng = np.random.default_rng(0)

--- a/tests/test_modelrunner.py
+++ b/tests/test_modelrunner.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 
 import nkululeko.glob_conf as glob_conf
-from nkululeko.modelrunner import Modelrunner
+from nkululeko.modelrunner import Modelrunner, validate_model_task_support
 from nkululeko.utils.errors import NkululukoError
 
 
@@ -133,6 +133,69 @@ class TestSelectModel:
         df_train, df_test, feats_train, feats_test = dummy_dfs
         mr = Modelrunner(df_train, df_test, feats_train, feats_test, run=0)
         assert isinstance(mr.model, SVR_model)
+
+    def test_classifier_model_with_regression_exp_raises(self, dummy_dfs):
+        glob_conf.config["EXP"]["type"] = "regression"
+        glob_conf.config["MODEL"]["type"] = "svm"
+        glob_conf.config["MODEL"]["measure"] = "mse"
+        df_train, df_test, feats_train, feats_test = dummy_dfs
+        with pytest.raises(NkululukoError):
+            Modelrunner(df_train, df_test, feats_train, feats_test, run=0)
+
+    def test_regressor_model_with_classification_exp_raises(self, dummy_dfs):
+        glob_conf.config["EXP"]["type"] = "classification"
+        glob_conf.config["MODEL"]["type"] = "svr"
+        df_train, df_test, feats_train, feats_test = dummy_dfs
+        with pytest.raises(NkululukoError):
+            Modelrunner(df_train, df_test, feats_train, feats_test, run=0)
+
+
+class _CapabilityStub:
+    """Minimal stand-in exposing is_classifier/is_regressor capability flags.
+
+    Used to exercise ``validate_model_task_support`` without instantiating
+    heavy real models.
+    """
+
+    def __init__(self, is_classifier=None, is_regressor=None):
+        self.is_classifier = is_classifier
+        self.is_regressor = is_regressor
+
+
+class TestValidateModelTaskSupport:
+    """Unit tests for validate_model_task_support capability-flag handling."""
+
+    def test_explicit_regressor_allows_svm_regression(self):
+        """A model declaring is_regressor=True may run a regression task even
+        when its model_type ('svm') is normally a classifier type."""
+        model = _CapabilityStub(is_classifier=False, is_regressor=True)
+        validate_model_task_support(model_type="svm", task="regression", model=model)
+
+    def test_explicit_classifier_allows_svr_classification(self):
+        """A model declaring is_classifier=True may run a classification task
+        even when its model_type ('svr') is normally a regressor type."""
+        model = _CapabilityStub(is_classifier=True, is_regressor=False)
+        validate_model_task_support(
+            model_type="svr", task="classification", model=model
+        )
+
+    def test_classifier_false_raises_for_classification(self):
+        """A model with is_classifier=False must not be used for
+        classification, even if its model_type ('svm') is a classifier type."""
+        model = _CapabilityStub(is_classifier=False, is_regressor=True)
+        with pytest.raises(NkululukoError):
+            validate_model_task_support(
+                model_type="svm", task="classification", model=model
+            )
+
+    def test_regressor_false_raises_for_regression(self):
+        """A model with is_regressor=False must not be used for regression,
+        even if its model_type ('svr') is a regressor type."""
+        model = _CapabilityStub(is_classifier=True, is_regressor=False)
+        with pytest.raises(NkululukoError):
+            validate_model_task_support(
+                model_type="svr", task="regression", model=model
+            )
 
 
 class TestCheckFeatureBalancing:


### PR DESCRIPTION
Main changes
* Add bidirectional model/experiment type compatibility validation before model instantiation
- Add CLASSIFIER_TYPES and REGRESSOR_TYPES sets to modelrunner.py
- Move compatibility check before model instantiation to fail fast
- Add reverse check: regressor model with classification experiment now errors
- Remove redundant post-instantiation check
- Add tests for both directions of incompatibility

Other changes (found during process)
* Fix multiple bugs: bare except, O(n²) concat, LabelEncoder error messages, dead code, exp type overwrite
* Fix flag aggregation in fill_train_and_tests: use any-wins semantics across all datasets
* Fix SonarCloud quality gate: extract _encode_labels_safe() to eliminate duplicate try/except blocks
* Address reviewer comments: loop over active splits for flag aggregation, add _tag_df helper in tests
* Fix SonarQube duplication and reviewer comments in PR #59
* Address code review: restore version/docstring, use MagicMock, clarify flag timing comments
* Refactor validate_model_task_support to fix SonarQube S3776
* Extract _check_task_capability() helper to reduce cognitive complexity from 17 to below the allowed 15, while preserving the exact capability-flag and type-fallback validation behavior. All 930 tests pass.
* Fix NaN crash in unseen-label error reporting; add missing reviewer-requested tests
* Also adds test coverage requested in review: any-wins flag aggregation propagating to self and all split DataFrames, and a regression test for the NaN crash.

Tests in test_datasplitter.py mutated glob_conf.config/glob_conf.target directly, which SonarQube flags (S8997) since it's global state that can leak between tests. Switch to the monkeypatch fixture, which auto-reverts after each test.



---------