### PR TITLE
Experiment context refactor (solve issue #37 in bagustris/nkululeko)

### DIFF
--- a/nkululeko/aug_train.py
+++ b/nkululeko/aug_train.py
@@ -10,7 +10,6 @@ import numpy as np
 from nkululeko.augment import doit as augment
 from nkululeko.constants import VERSION
 import nkululeko.experiment as exp
-import nkululeko.glob_conf as glob_conf
 from nkululeko.utils.util import Util
 
 
@@ -28,7 +27,7 @@ def doit(config_file):
     expr = exp.Experiment(config)
     module = "aug_train"
     expr.set_module(module)
-    util = Util(module)
+    util = Util(module, context=expr.context)
     util.debug(
         f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
     )
@@ -45,23 +44,24 @@ def doit(config_file):
     augmentings = "_".join(augmentings)
     result_file = f"augmented_{augmentings}.csv"
 
-    glob_conf.config["DATA"]["no_reuse"] = "True"
-    glob_conf.config["FEATS"]["no_reuse"] = "True"
-    glob_conf.config["AUGMENT"]["sample_selection"] = "train"
-    glob_conf.config["AUGMENT"]["result"] = f"./{result_file}"
+    config = expr.context.config
+    config["DATA"]["no_reuse"] = "True"
+    config["FEATS"]["no_reuse"] = "True"
+    config["AUGMENT"]["sample_selection"] = "train"
+    config["AUGMENT"]["result"] = f"./{result_file}"
     tmp_config = "tmp.ini"
     with open(tmp_config, "w") as config_file:
-        glob_conf.config.write(config_file)
+        config.write(config_file)
     augment(tmp_config)
     databases = ast.literal_eval(config["DATA"]["databases"])
     aug_name = f"aug_{augmentings}"
     databases.append(aug_name)
-    glob_conf.config["DATA"]["databases"] = str(databases)
-    glob_conf.config["DATA"][aug_name] = f"{util.get_exp_dir()}/{result_file}"
-    glob_conf.config["DATA"][f"{aug_name}.type"] = "csv"
-    glob_conf.config["DATA"][f"{aug_name}.rename_speakers"] = "True"
-    glob_conf.config["DATA"][f"{aug_name}.split_strategy"] = "train"
-    util.set_config(glob_conf.config)
+    config["DATA"]["databases"] = str(databases)
+    config["DATA"][aug_name] = f"{util.get_exp_dir()}/{result_file}"
+    config["DATA"][f"{aug_name}.type"] = "csv"
+    config["DATA"][f"{aug_name}.rename_speakers"] = "True"
+    config["DATA"][f"{aug_name}.split_strategy"] = "train"
+    util.set_config(config)
     # load the data
     expr.load_datasets()
 

--- a/nkululeko/autopredict/ap_age.py
+++ b/nkululeko/autopredict/ap_age.py
@@ -5,7 +5,6 @@ Currently based on audEERING's agender model.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -23,9 +22,13 @@ class AgePredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting age for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["agender_agender"], feats_name, split_selection
+            self.df,
+            ["agender_agender"],
+            feats_name,
+            split_selection,
+            context=self.util.context,
         )
         agender_df = self.feature_extractor.extract()
         pred_age = agender_df.age * 100

--- a/nkululeko/autopredict/ap_arousal.py
+++ b/nkululeko/autopredict/ap_arousal.py
@@ -5,7 +5,6 @@ Currently based on audEERING's emotional dimension model.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -23,9 +22,9 @@ class ArousalPredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting arousal for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["auddim"], feats_name, split_selection
+            self.df, ["auddim"], feats_name, split_selection, context=self.util.context
         )
         pred_df = self.feature_extractor.extract()
         pred_vals = pred_df.arousal * 1000

--- a/nkululeko/autopredict/ap_dominance.py
+++ b/nkululeko/autopredict/ap_dominance.py
@@ -5,7 +5,6 @@ Currently based on audEERING's emotional dimension model.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -22,9 +21,9 @@ class DominancePredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting dominance for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["auddim"], feats_name, split_selection
+            self.df, ["auddim"], feats_name, split_selection, context=self.util.context
         )
         pred_df = self.feature_extractor.extract()
         pred_vals = pred_df.dominance * 1000

--- a/nkululeko/autopredict/ap_emotion.py
+++ b/nkululeko/autopredict/ap_emotion.py
@@ -5,7 +5,6 @@ Uses emotion2vec models for emotion prediction.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -22,10 +21,14 @@ class EmotionPredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting emotion for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
 
         self.feature_extractor = FeatureExtractor(
-            self.df, ["emotion2vec-large"], feats_name, split_selection
+            self.df,
+            ["emotion2vec-large"],
+            feats_name,
+            split_selection,
+            context=self.util.context,
         )
         emotion_df = self.feature_extractor.extract()
 

--- a/nkululeko/autopredict/ap_gender.py
+++ b/nkululeko/autopredict/ap_gender.py
@@ -5,7 +5,6 @@ Currently based on audEERING's agender model.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -23,9 +22,13 @@ class GenderPredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting gender for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["agender_agender"], feats_name, split_selection
+            self.df,
+            ["agender_agender"],
+            feats_name,
+            split_selection,
+            context=self.util.context,
         )
         agender_df = self.feature_extractor.extract()
         pred_gender = agender_df.drop("age", axis=1).idxmax(axis=1)

--- a/nkululeko/autopredict/ap_mos.py
+++ b/nkululeko/autopredict/ap_mos.py
@@ -6,7 +6,6 @@ import ast
 
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -25,9 +24,9 @@ class MOSPredictor:
     def predict(self, split_selection):
         self.util.debug(f"estimating MOS for {split_selection} samples")
         return_df = self.df.copy()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["mos"], feats_name, split_selection
+            self.df, ["mos"], feats_name, split_selection, context=self.util.context
         )
         result_df = self.feature_extractor.extract()
         # replace missing values by 0

--- a/nkululeko/autopredict/ap_pesq.py
+++ b/nkululeko/autopredict/ap_pesq.py
@@ -6,7 +6,6 @@ import ast
 
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -25,9 +24,9 @@ class PESQPredictor:
     def predict(self, split_selection):
         self.util.debug(f"estimating PESQ for {split_selection} samples")
         return_df = self.df.copy()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["squim"], feats_name, split_selection
+            self.df, ["squim"], feats_name, split_selection, context=self.util.context
         )
         result_df = self.feature_extractor.extract()
         # replace missing values by 0

--- a/nkululeko/autopredict/ap_sdr.py
+++ b/nkululeko/autopredict/ap_sdr.py
@@ -7,7 +7,6 @@ import ast
 
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -26,9 +25,9 @@ class SDRPredictor:
     def predict(self, split_selection):
         self.util.debug(f"estimating SDR for {split_selection} samples")
         return_df = self.df.copy()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["squim"], feats_name, split_selection
+            self.df, ["squim"], feats_name, split_selection, context=self.util.context
         )
         result_df = self.feature_extractor.extract()
         # replace missing values by 0

--- a/nkululeko/autopredict/ap_snr.py
+++ b/nkululeko/autopredict/ap_snr.py
@@ -6,7 +6,6 @@ import ast
 
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -25,9 +24,9 @@ class SNRPredictor:
     def predict(self, split_selection):
         self.util.debug(f"estimating SNR for {split_selection} samples")
         return_df = self.df.copy()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["snr"], feats_name, split_selection
+            self.df, ["snr"], feats_name, split_selection, context=self.util.context
         )
         result_df = self.feature_extractor.extract()
         # replace missing values by 0

--- a/nkululeko/autopredict/ap_stoi.py
+++ b/nkululeko/autopredict/ap_stoi.py
@@ -6,7 +6,6 @@ import ast
 
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -25,9 +24,9 @@ class STOIPredictor:
     def predict(self, split_selection):
         self.util.debug(f"estimating STOI for {split_selection} samples")
         return_df = self.df.copy()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["squim"], feats_name, split_selection
+            self.df, ["squim"], feats_name, split_selection, context=self.util.context
         )
         result_df = self.feature_extractor.extract()
         # replace missing values by 0

--- a/nkululeko/autopredict/ap_valence.py
+++ b/nkululeko/autopredict/ap_valence.py
@@ -5,7 +5,6 @@ Currently based on audEERING's emotional dimension model.
 
 import ast
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.utils.util import Util
 
@@ -23,9 +22,9 @@ class ValencePredictor:
 
     def predict(self, split_selection):
         self.util.debug(f"predicting valence for {split_selection} samples")
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["databases"]))
+        feats_name = "_".join(ast.literal_eval(self.util.config["DATA"]["databases"]))
         self.feature_extractor = FeatureExtractor(
-            self.df, ["auddim"], feats_name, split_selection
+            self.df, ["auddim"], feats_name, split_selection, context=self.util.context
         )
         pred_df = self.feature_extractor.extract()
         pred_vals = pred_df.valence * 1000

--- a/nkululeko/balance.py
+++ b/nkululeko/balance.py
@@ -7,21 +7,22 @@ including over-sampling, under-sampling, and combination methods.
 """
 
 import pandas as pd
+from nkululeko.experiment_context import ContextAware
 from nkululeko.utils.util import Util
-import nkululeko.glob_conf as glob_conf
 
 
-class DataBalancer:
+class DataBalancer(ContextAware):
     """Class to handle data and feature balancing operations."""
 
-    def __init__(self, random_state=42):
+    def __init__(self, random_state=42, context=None):
         """
         Initialize the DataBalancer.
 
         Args:
             random_state (int): Random state for reproducible results
         """
-        self.util = Util("data_balancer")
+        self.util = Util("data_balancer", context=context)
+        self.context = self.util.context
         self.random_state = random_state
 
         # Supported balancing algorithms
@@ -205,9 +206,9 @@ class DataBalancer:
     def _log_class_distribution(self, y_res, method):
         """Log class distribution with label names if possible."""
         # Check if label encoder is available for pretty printing
-        if hasattr(glob_conf, "label_encoder") and glob_conf.label_encoder is not None:
+        if self.context.label_encoder is not None:
             try:
-                le = glob_conf.label_encoder
+                le = self.context.label_encoder
                 res = pd.Series(y_res).value_counts()
                 resd = {}
                 for i, label_idx in enumerate(res.index.values):

--- a/nkululeko/bundle.py
+++ b/nkululeko/bundle.py
@@ -30,7 +30,6 @@ import sys
 
 import audeer
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
 from nkululeko.utils.files import safe_path
@@ -201,7 +200,7 @@ def export_bundle(config_file, output_dir=None):
     # Create experiment and load saved state
     expr = Experiment(config)
     expr.set_module("bundle")
-    util = Util("bundle", has_config=True)
+    util = Util("bundle", has_config=True, context=expr.context)
     util.debug(f"nkululeko {VERSION}: bundle export from {config_file}")
 
     # Load the saved experiment
@@ -213,7 +212,7 @@ def export_bundle(config_file, output_dir=None):
         )
 
     expr.load(save_name)
-    glob_conf.set_label_encoder(expr.label_encoder)
+    expr.context.label_encoder = expr.label_encoder
 
     # Gather metadata
     target = util.config_val("DATA", "target", "emotion")

--- a/nkululeko/data/dataset.py
+++ b/nkululeko/data/dataset.py
@@ -9,14 +9,14 @@ import pandas as pd
 import audformat
 
 from nkululeko.filter_data import DataFilter
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.plots import Plots
 from nkululeko.reporting.report_item import ReportItem
 from nkululeko.utils.util import Util
 from nkululeko.constants import COL_AGE, COL_SEX, COL_SPEAKER
 
 
-class Dataset:
+class Dataset(ContextAware):
     """Class to represent datasets"""
 
     name = ""  # An identifier for the dataset
@@ -26,12 +26,13 @@ class Dataset:
     df_train = None  # The training split
     df_test = None  # The evaluation split
 
-    def __init__(self, name):
+    def __init__(self, name, context=None):
         """Constructor setting up name and configuration"""
         self.name = name
-        self.util = Util("dataset")
+        self.util = Util("dataset", context=context)
+        self.context = self.util.context
         self.target = self.util.config_val("DATA", "target", None)
-        self.plot = Plots()
+        self.plot = Plots(context=self.context)
         self.limit = int(self.util.config_val_data(self.name, "limit", 0))
         self.target_tables_append = eval(
             self.util.config_val_data(self.name, "target_tables_append", "False")
@@ -49,7 +50,7 @@ class Dataset:
             False,
             False,
         )
-        self.split3 = glob_conf.split3
+        self.split3 = self.context.split3
         self.feats = None
 
     def _get_tables(self):
@@ -137,9 +138,9 @@ class Dataset:
             f" {self.got_speaker} ({speaker_num}), got sexes: {self.got_gender}"
         )
         self.util.debug(r_string)
-        if glob_conf.report.initial:
-            glob_conf.report.add_item(ReportItem("Data", "Load report", r_string))
-            glob_conf.report.initial = False
+        if self.context.report.initial:
+            self.context.report.add_item(ReportItem("Data", "Load report", r_string))
+            self.context.report.initial = False
 
     def _autodetect_experiment_type(self, df):
         """Auto-detect the experiment type from the label column.
@@ -154,7 +155,7 @@ class Dataset:
             return
         user_type = self.util.config_val("EXP", "type", None)
         if user_type is None:
-            glob_conf.config["EXP"]["type"] = "regression"
+            self.context.config["EXP"]["type"] = "regression"
         elif user_type != "regression":
             self.util.warn(
                 f"{self.name}: Configured [EXP] type={user_type} but label "
@@ -177,7 +178,7 @@ class Dataset:
             if columns:
                 self.col_label = columns[0]
                 self.target = self.col_label
-                glob_conf.config["DATA"]["target"] = self.target
+                self.context.config["DATA"]["target"] = self.target
                 # Warn about automatic target selection which might pick wrong column
                 self.util.warn(
                     f"{self.name}: No target specified, automatically selected '{self.col_label}' "
@@ -254,7 +255,7 @@ class Dataset:
                 f" filtered {pre - post})"
             )
 
-        datafilter = DataFilter(self.df)
+        datafilter = DataFilter(self.df, context=self.context)
         self.df = datafilter.all_filters(data_name=self.name)
 
         if self.got_speaker and self.util.config_val_data(
@@ -592,7 +593,7 @@ class Dataset:
             from nkululeko.feature_extractor import FeatureExtractor
 
             self.feature_extractor = FeatureExtractor(
-                self.df, feats_types, self.name, "all"
+                self.df, feats_types, self.name, "all", context=self.context
             )
             self.feats = self.feature_extractor.extract()
         return self.feats, self.feature_extractor
@@ -710,7 +711,7 @@ class Dataset:
     def prepare_labels(self):
         # strategy = self.util.config_val("DATA", "strategy", "train_test")
         only_tests = eval(self.util.config_val("DATA", "tests", "False"))
-        module = glob_conf.module
+        module = self.context.module
         if only_tests and module == "test":
             self.df_test = self.map_labels(self.df_test)
             self.df_test = self._add_labels(self.df_test)
@@ -767,7 +768,7 @@ class Dataset:
         ):
             return df
         """Rename the labels and remove the ones that are not needed."""
-        target = glob_conf.config["DATA"]["target"]
+        target = self.context.config["DATA"]["target"]
         if target not in df.columns:
             return df
         # see if a special mapping should be used
@@ -814,7 +815,7 @@ class Dataset:
             self.util.debug(f"{self.name}: binning continuous variable to categories")
             cat_vals = self.util.continuous_to_categorical(df[self.target])
             df[self.target] = cat_vals.values
-            labels = ast.literal_eval(glob_conf.config["DATA"]["labels"])
+            labels = ast.literal_eval(self.context.config["DATA"]["labels"])
             df["class_label"] = df[self.target]
             for i, label in enumerate(labels):
                 df["class_label"] = df["class_label"].replace(i, str(label))

--- a/nkululeko/data/dataset.py
+++ b/nkululeko/data/dataset.py
@@ -8,15 +8,15 @@ import audformat
 import numpy as np
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import COL_AGE, COL_SEX, COL_SPEAKER
+from nkululeko.experiment_context import ContextAware
 from nkululeko.filter_data import DataFilter
 from nkululeko.plots import Plots
 from nkululeko.reporting.report_item import ReportItem
 from nkululeko.utils.util import Util
 
 
-class Dataset:
+class Dataset(ContextAware):
     """Class to represent datasets"""
 
     name = ""  # An identifier for the dataset
@@ -26,12 +26,13 @@ class Dataset:
     df_train = None  # The training split
     df_test = None  # The evaluation split
 
-    def __init__(self, name):
+    def __init__(self, name, context=None):
         """Constructor setting up name and configuration"""
         self.name = name
-        self.util = Util("dataset")
+        self.util = Util("dataset", context=context)
+        self.context = self.util.context
         self.target = self.util.config_val("DATA", "target", None)
-        self.plot = Plots()
+        self.plot = Plots(context=self.context)
         self.limit = int(self.util.config_val_data(self.name, "limit", 0))
         self.start_fresh = eval(self.util.config_val("DATA", "no_reuse", "False"))
         self.is_labeled, self.got_speaker, self.got_gender, self.got_age = (
@@ -40,7 +41,7 @@ class Dataset:
             False,
             False,
         )
-        self.split3 = glob_conf.split3
+        self.split3 = self.context.split3
         self.feats = None
 
     def _get_tables(self):
@@ -127,9 +128,9 @@ class Dataset:
             f" {self.got_speaker} ({speaker_num}), got sexes: {self.got_gender}"
         )
         self.util.debug(r_string)
-        if glob_conf.report.initial:
-            glob_conf.report.add_item(ReportItem("Data", "Load report", r_string))
-            glob_conf.report.initial = False
+        if self.context.report.initial:
+            self.context.report.add_item(ReportItem("Data", "Load report", r_string))
+            self.context.report.initial = False
 
     def _autodetect_experiment_type(self, df):
         """Auto-detect the experiment type from the label column.
@@ -144,7 +145,7 @@ class Dataset:
             return
         user_type = self.util.config_val("EXP", "type", None)
         if user_type is None:
-            glob_conf.config["EXP"]["type"] = "regression"
+            self.context.config["EXP"]["type"] = "regression"
         elif user_type != "regression":
             self.util.warn(
                 f"{self.name}: Configured [EXP] type={user_type} but label "
@@ -167,7 +168,7 @@ class Dataset:
             if columns:
                 self.col_label = columns[0]
                 self.target = self.col_label
-                glob_conf.config["DATA"]["target"] = self.target
+                self.context.config["DATA"]["target"] = self.target
                 # Warn about automatic target selection which might pick wrong column
                 self.util.warn(
                     f"{self.name}: No target specified, automatically selected '{self.col_label}' "
@@ -244,7 +245,7 @@ class Dataset:
                 f" filtered {pre - post})"
             )
 
-        datafilter = DataFilter(self.df)
+        datafilter = DataFilter(self.df, context=self.context)
         self.df = datafilter.all_filters(data_name=self.name)
 
         if self.got_speaker and self.util.config_val_data(
@@ -582,7 +583,7 @@ class Dataset:
             from nkululeko.feature_extractor import FeatureExtractor
 
             self.feature_extractor = FeatureExtractor(
-                self.df, feats_types, self.name, "all"
+                self.df, feats_types, self.name, "all", context=self.context
             )
             self.feats = self.feature_extractor.extract()
         return self.feats, self.feature_extractor
@@ -700,7 +701,7 @@ class Dataset:
     def prepare_labels(self):
         # strategy = self.util.config_val("DATA", "strategy", "train_test")
         only_tests = eval(self.util.config_val("DATA", "tests", "False"))
-        module = glob_conf.module
+        module = self.context.module
         if only_tests and module == "test":
             self.df_test = self.map_labels(self.df_test)
             self.df_test = self._add_labels(self.df_test)
@@ -757,7 +758,7 @@ class Dataset:
         ):
             return df
         """Rename the labels and remove the ones that are not needed."""
-        target = glob_conf.config["DATA"]["target"]
+        target = self.context.config["DATA"]["target"]
         if target not in df.columns:
             return df
         # see if a special mapping should be used
@@ -804,7 +805,7 @@ class Dataset:
             self.util.debug(f"{self.name}: binning continuous variable to categories")
             cat_vals = self.util.continuous_to_categorical(df[self.target])
             df[self.target] = cat_vals.values
-            labels = ast.literal_eval(glob_conf.config["DATA"]["labels"])
+            labels = ast.literal_eval(self.context.config["DATA"]["labels"])
             df["class_label"] = df[self.target]
             for i, label in enumerate(labels):
                 df["class_label"] = df["class_label"].replace(i, str(label))

--- a/nkululeko/data/dataset_csv.py
+++ b/nkululeko/data/dataset_csv.py
@@ -8,7 +8,6 @@ import pandas as pd
 import audformat.utils
 
 from nkululeko.data.dataset import Dataset
-import nkululeko.glob_conf as glob_conf
 from nkululeko.reporting.report_item import ReportItem
 
 
@@ -115,7 +114,7 @@ class Dataset_CSV(Dataset):
                 f" {self.got_gender}, got age: {self.got_age}"
             )
         self.util.debug(r_string)
-        glob_conf.report.add_item(ReportItem("Data", "Loaded report", r_string))
+        self.context.report.add_item(ReportItem("Data", "Loaded report", r_string))
 
     def prepare(self):
         super().prepare()

--- a/nkululeko/data/datasplitter.py
+++ b/nkululeko/data/datasplitter.py
@@ -8,18 +8,19 @@ import secrets
 from sklearn.preprocessing import LabelEncoder
 import pickle
 from nkululeko.filter_data import DataFilter
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.file_checker import FileChecker
 from nkululeko.utils.util import Util
 
 
-class Datasplitter:
-    def __init__(self, datasets):
-        self.util = Util("datasplitter")
+class Datasplitter(ContextAware):
+    def __init__(self, datasets, context=None):
+        self.util = Util("datasplitter", context=context)
+        self.context = self.util.context
         self.datasets = datasets
-        self.split3 = glob_conf.split3
-        self.target = glob_conf.target
-        self.got_speaker = glob_conf.got_speaker
+        self.split3 = self.context.split3
+        self.target = self.context.target
+        self.got_speaker = self.context.got_speaker
 
     def get_sample_selection(self) -> pd.DataFrame:
         """Get the dataframe based on the sample selection configuration.
@@ -42,7 +43,7 @@ class Datasplitter:
         return df
 
     def _add_random_target(self, df):
-        labels = glob_conf.labels
+        labels = self.context.labels
         a = [None] * len(df)
         for i in range(0, len(df)):
             a[i] = secrets.choice(labels)
@@ -108,18 +109,18 @@ class Datasplitter:
             "EXP", "filter.sample_selection", "all"
         )
         if filter_sample_selection == "all":
-            datafilter = DataFilter(self.df_train)
+            datafilter = DataFilter(self.df_train, context=self.context)
             self.df_train = datafilter.all_filters()
-            datafilter = DataFilter(self.df_test)
+            datafilter = DataFilter(self.df_test, context=self.context)
             self.df_test = datafilter.all_filters()
             if self.split3:
-                datafilter = DataFilter(self.df_dev)
+                datafilter = DataFilter(self.df_dev, context=self.context)
                 self.df_dev = datafilter.all_filters()
         elif filter_sample_selection == "train":
-            datafilter = DataFilter(self.df_train)
+            datafilter = DataFilter(self.df_train, context=self.context)
             self.df_train = datafilter.all_filters()
         elif filter_sample_selection == "test":
-            datafilter = DataFilter(self.df_test)
+            datafilter = DataFilter(self.df_test, context=self.context)
             self.df_test = datafilter.all_filters()
         else:
             msg = (
@@ -154,7 +155,7 @@ class Datasplitter:
                     dev_cats = self.df_dev[self.target].value_counts().to_string()
             # encode the labels as numbers
             self.label_encoder = LabelEncoder()
-            glob_conf.set_label_encoder(self.label_encoder)
+            self.context.label_encoder = self.label_encoder
             if not self.df_train.empty:
                 self.util.debug(f"Categories train: {train_cats}")
                 self.df_train[self.target] = self.label_encoder.fit_transform(

--- a/nkululeko/data/datasplitter.py
+++ b/nkululeko/data/datasplitter.py
@@ -7,20 +7,20 @@ import secrets
 
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
-
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.file_checker import FileChecker
 from nkululeko.filter_data import DataFilter
 from nkululeko.utils.util import Util
 
 
-class Datasplitter:
-    def __init__(self, datasets):
-        self.util = Util("datasplitter")
+class Datasplitter(ContextAware):
+    def __init__(self, datasets, context=None):
+        self.util = Util("datasplitter", context=context)
+        self.context = self.util.context
         self.datasets = datasets
-        self.split3 = glob_conf.split3
-        self.target = glob_conf.target
-        self.got_speaker = glob_conf.got_speaker
+        self.split3 = self.context.split3
+        self.target = self.context.target
+        self.got_speaker = self.context.got_speaker
 
     def get_sample_selection(self) -> pd.DataFrame:
         """Get the dataframe based on the sample selection configuration.
@@ -62,7 +62,7 @@ class Datasplitter:
             )
 
     def _add_random_target(self, df):
-        labels = glob_conf.labels
+        labels = self.context.labels
         a = [None] * len(df)
         for i in range(0, len(df)):
             a[i] = secrets.choice(labels)
@@ -140,18 +140,18 @@ class Datasplitter:
             "EXP", "filter.sample_selection", "all"
         )
         if filter_sample_selection == "all":
-            datafilter = DataFilter(self.df_train)
+            datafilter = DataFilter(self.df_train, context=self.context)
             self.df_train = datafilter.all_filters()
-            datafilter = DataFilter(self.df_test)
+            datafilter = DataFilter(self.df_test, context=self.context)
             self.df_test = datafilter.all_filters()
             if self.split3:
-                datafilter = DataFilter(self.df_dev)
+                datafilter = DataFilter(self.df_dev, context=self.context)
                 self.df_dev = datafilter.all_filters()
         elif filter_sample_selection == "train":
-            datafilter = DataFilter(self.df_train)
+            datafilter = DataFilter(self.df_train, context=self.context)
             self.df_train = datafilter.all_filters()
         elif filter_sample_selection == "test":
-            datafilter = DataFilter(self.df_test)
+            datafilter = DataFilter(self.df_test, context=self.context)
             self.df_test = datafilter.all_filters()
         else:
             msg = (
@@ -186,7 +186,7 @@ class Datasplitter:
                     dev_cats = self.df_dev[self.target].value_counts().to_string()
             # encode the labels as numbers
             self.label_encoder = LabelEncoder()
-            glob_conf.set_label_encoder(self.label_encoder)
+            self.context.label_encoder = self.label_encoder
             if not self.df_train.empty:
                 self.util.debug(f"Categories train: {train_cats}")
                 self.df_train[self.target] = self.label_encoder.fit_transform(

--- a/nkululeko/demo_predictor.py
+++ b/nkululeko/demo_predictor.py
@@ -7,7 +7,6 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.utils.util import Util
 import warnings
 
@@ -15,15 +14,25 @@ warnings.simplefilter(action="ignore", category=pd.errors.PerformanceWarning)
 
 
 class Demo_predictor:
-    def __init__(self, model, file, is_list, feature_extractor, label_encoder, outfile):
+    def __init__(
+        self,
+        model,
+        file,
+        is_list,
+        feature_extractor,
+        label_encoder,
+        outfile,
+        context=None,
+    ):
         """Constructor setting up name and configuration."""
         self.model = model
         self.feature_extractor = feature_extractor
         self.label_encoder = label_encoder
         self.is_list = is_list
         self.sr = 16000
-        self.target = glob_conf.config["DATA"]["target"]
-        self.util = Util("demo_predictor")
+        self.util = Util("demo_predictor", context=context)
+        self.context = self.util.context
+        self.target = self.context.config["DATA"]["target"]
         self.file = file
         self.outfile = outfile
 
@@ -76,7 +85,7 @@ class Demo_predictor:
                             else:
                                 file_list.append(line)
                 for file_name in file_list:
-                    test_folder = glob_conf.config["DATA"]["test_folder"]
+                    test_folder = self.context.config["DATA"]["test_folder"]
                     file_path = os.path.join(test_folder, file_name.strip())
                     sig, sr = audiofile.read(file_path)
                     print(f"predicting file {file_path}")

--- a/nkululeko/experiment.py
+++ b/nkululeko/experiment.py
@@ -9,11 +9,15 @@ import audeer
 import audformat
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.data.dataset import Dataset
 from nkululeko.data.dataset_csv import Dataset_CSV
 from nkululeko.data.datasplitter import Datasplitter
 from nkululeko.demo_predictor import Demo_predictor
+from nkululeko.experiment_context import (
+    ExperimentContext,
+    bind_experiment_context,
+    set_context,
+)
 from nkululeko.feat_extract.feats_analyser import FeatureAnalyser
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.plots import Plots
@@ -25,6 +29,7 @@ from nkululeko.utils.pickle_integrity import save_checksum, verify_checksum
 from nkululeko.utils.util import Util
 
 
+@bind_experiment_context
 class Experiment:
     """Main class specifying an experiment."""
 
@@ -34,15 +39,20 @@ class Experiment:
         Args:
             - config_obj : a config parser object that sets the experiment parameters and being set as a global object.
         """
-        self.set_globals(config_obj)
-        self.name = glob_conf.config["EXP"]["name"]
-        self.root = os.path.join(glob_conf.config["EXP"]["root"], "")
+        self.context = ExperimentContext(config=config_obj)
+        set_context(self.context)
+        self._initialize()
+
+    def _initialize(self):
+        """Initialize this experiment while its context is active."""
+        self.name = self.context.config["EXP"]["name"]
+        self.root = os.path.join(self.context.config["EXP"]["root"], "")
         self.data_dir = os.path.join(self.root, self.name)
         audeer.mkdir(self.data_dir)  # create the experiment directory
-        self.util = Util("experiment")
-        glob_conf.set_util(self.util)
+        self.util = Util("experiment", context=self.context)
+        self.context.util = self.util
         self.split3 = eval(self.util.config_val("EXP", "traindevtest", "False"))
-        glob_conf.set_split3(self.split3)
+        self.context.split3 = self.split3
         fresh_report = eval(self.util.config_val("REPORT", "fresh", "False"))
         if not fresh_report:
             try:
@@ -55,7 +65,7 @@ class Experiment:
         else:
             self.util.debug("starting a fresh report")
             self.report = Report()
-        glob_conf.set_report(self.report)
+        self.context.report = self.report
         self.loso = self.util.config_val("MODEL", "loso", False)
         self.logo = self.util.config_val("MODEL", "logo", False)
         self.xfoldx = self.util.config_val("MODEL", "k_fold_cross", False)
@@ -68,7 +78,7 @@ class Experiment:
         self.feats_dev = None
 
     def set_module(self, module):
-        glob_conf.set_module(module)
+        self.context.module = module
 
     def store_report(self):
         report_path = os.path.join(self.data_dir, "report.pkl")
@@ -85,20 +95,20 @@ class Experiment:
     #     return self.util.get_exp_name()
 
     def set_globals(self, config_obj):
-        """Install a config object in the global space."""
-        glob_conf.init_config(config_obj)
+        """Replace this experiment's configuration."""
+        self.context.config = config_obj
 
     def load_datasets(self):
         """Load all databases specified in the configuration and map the labels."""
-        ds = ast.literal_eval(glob_conf.config["DATA"]["databases"])
+        ds = ast.literal_eval(self.context.config["DATA"]["databases"])
         self.datasets = {}
         self.got_speaker, self.got_gender, self.got_age = False, False, False
         for d in ds:
             ds_type = self.util.config_val_data(d, "type", "audformat")
             if ds_type == "audformat":
-                data = Dataset(d)
+                data = Dataset(d, context=self.context)
             elif ds_type == "csv":
-                data = Dataset_CSV(d)
+                data = Dataset_CSV(d, context=self.context)
             else:
                 self.util.error(f"unknown data type: {ds_type}")
             data.load()
@@ -111,8 +121,8 @@ class Experiment:
                 self.got_speaker = True
             self.datasets.update({d: data})
         self.target = self.util.config_val("DATA", "target", None)
-        glob_conf.set_got_speaker(self.got_speaker)
-        glob_conf.set_target(self.target)
+        self.context.got_speaker = self.got_speaker
+        self.context.target = self.target
         # print target via debug
         self.util.debug(f"target: {self.target}")
         # print keys/column
@@ -130,9 +140,9 @@ class Experiment:
             self.labels = auto_labels
         # print autolabel no matter it is specified or not
         self.util.debug(f"Labels (from database): {auto_labels}")
-        glob_conf.set_labels(self.labels)
+        self.context.labels = self.labels
         self.util.debug(f"loaded databases {dbs}")
-        self.datasplitter = Datasplitter(self.datasets)
+        self.datasplitter = Datasplitter(self.datasets, context=self.context)
 
     def _import_csv(self, storage):
         # df = pd.read_csv(storage, header=0, index_col=[0,1,2])
@@ -160,7 +170,7 @@ class Experiment:
                 keep original string labels (the caller is then responsible for
                 encoding before passing the dataframe to a model).
         """
-        test_dbs = ast.literal_eval(glob_conf.config["DATA"]["tests"])
+        test_dbs = ast.literal_eval(self.context.config["DATA"]["tests"])
         self.df_test = pd.DataFrame()
         start_fresh = eval(self.util.config_val("DATA", "no_reuse", "False"))
         store = self.util.get_path("store")
@@ -173,9 +183,9 @@ class Experiment:
             for d in test_dbs:
                 ds_type = self.util.config_val_data(d, "type", "audformat")
                 if ds_type == "audformat":
-                    data = Dataset(d)
+                    data = Dataset(d, context=self.context)
                 elif ds_type == "csv":
-                    data = Dataset_CSV(d)
+                    data = Dataset_CSV(d, context=self.context)
                 else:
                     self.util.error(f"unknown data type: {ds_type}")
                 data.load()
@@ -219,14 +229,14 @@ class Experiment:
         else:
             self.df_train, self.df_test = self.datasplitter.fill_train_and_tests()
         self.test_ds_df = getattr(self.datasplitter, "test_ds_df", {})
-        self.label_encoder = glob_conf.label_encoder
+        self.label_encoder = self.context.label_encoder
 
     def extract_test_feats(self):
         self.feats_test = pd.DataFrame()
-        feats_name = "_".join(ast.literal_eval(glob_conf.config["DATA"]["tests"]))
+        feats_name = "_".join(ast.literal_eval(self.context.config["DATA"]["tests"]))
         feats_types = self.util.config_val_list("FEATS", "type", ["os"])
         self.feature_extractor = FeatureExtractor(
-            self.df_test, feats_types, feats_name, "test"
+            self.df_test, feats_types, feats_name, "test", context=self.context
         )
         self.feats_test = self.feature_extractor.extract()
         self.util.debug(f"Test features shape:{self.feats_test.shape}")
@@ -302,7 +312,7 @@ class Experiment:
 
         Per target class and biological sex.
         """
-        plot = Plots()
+        plot = Plots(context=self.context)
         plot.plot_distributions(df_labels)
         if self.got_speaker:
             plot.plot_distributions_speaker(df_labels)
@@ -541,7 +551,9 @@ class Experiment:
                 f"unknown sample selection specifier {sample_selection}, should"
                 " be [all | train | test]"
             )
-        feat_analyser = FeatureAnalyser(sample_selection, df_labels, df_feats)
+        feat_analyser = FeatureAnalyser(
+            sample_selection, df_labels, df_feats, context=self.context
+        )
         # check if SHAP features should be analysed
         shap = eval(self.util.config_val("EXPL", "shap", "False"))
         if shap:
@@ -578,7 +590,7 @@ class Experiment:
         if list_of_dimreds:
             dimreds = list_of_dimreds
             scat_targets = ast.literal_eval(scatter_target)
-            plots = Plots()
+            plots = Plots(context=self.context)
             for scat_target in scat_targets:
                 # Check if this is the target column that was label-encoded
                 is_encoded_target = (
@@ -615,7 +627,7 @@ class Experiment:
             target_column = self.util.config_val("DATA", "target", "emotion")
             # Decode labels if they were encoded
             target_column = self._decode_labels(df_labels, target_column)
-            plots = Plots()
+            plots = Plots(context=self.context)
             self.util.debug("generating t-SNE plot...")
             plots.scatter_plot(df_feats, df_labels, target_column, "tsne")
 
@@ -625,7 +637,7 @@ class Experiment:
             target_column = self.util.config_val("DATA", "target", "emotion")
             # Decode labels if they were encoded
             target_column = self._decode_labels(df_labels, target_column)
-            plots = Plots()
+            plots = Plots(context=self.context)
             self.util.debug("generating UMAP plot...")
             plots.scatter_plot(df_feats, df_labels, target_column, "umap")
 
@@ -635,7 +647,7 @@ class Experiment:
             target_column = self.util.config_val("DATA", "target", "emotion")
             # Decode labels if they were encoded
             target_column = self._decode_labels(df_labels, target_column)
-            plots = Plots()
+            plots = Plots(context=self.context)
             self.util.debug("generating PCA plot...")
             plots.scatter_plot(df_feats, df_labels, target_column, "pca")
 
@@ -656,6 +668,7 @@ class Experiment:
                 scale_feats,
                 dev_x=self.df_dev,
                 dev_y=self.feats_dev,
+                context=self.context,
             )
             if self.split3:
                 self.feats_train, self.feats_dev, self.feats_test = (
@@ -681,10 +694,15 @@ class Experiment:
                 self.feats_test,
                 dev_x=self.df_dev,
                 dev_y=self.feats_dev,
+                context=self.context,
             )
         else:
             self.runmgr = Runmanager(
-                self.df_train, self.df_test, self.feats_train, self.feats_test
+                self.df_train,
+                self.df_test,
+                self.feats_train,
+                self.feats_test,
+                context=self.context,
             )
 
     def run(self):
@@ -774,7 +792,13 @@ class Experiment:
         except AttributeError:
             pass
         demo = Demo_predictor(
-            model, file, is_list, self.datasplitter.feature_extractor, lab_enc, outfile
+            model,
+            file,
+            is_list,
+            self.datasplitter.feature_extractor,
+            lab_enc,
+            outfile,
+            context=self.context,
         )
         demo.run_demo()
 
@@ -782,12 +806,17 @@ class Experiment:
         model = self.runmgr.get_best_model()
         model.set_testdata(self.df_test, self.feats_test)
         test_predictor = TestPredictor(
-            model, self.df_test, self.label_encoder, result_name
+            model,
+            self.df_test,
+            self.label_encoder,
+            result_name,
+            context=self.context,
         )
         result = test_predictor.predict_and_store()
         return result
 
     def load(self, filename):
+        context = self.context
         try:
             verify_checksum(filename)
             f = open(filename, "rb")
@@ -795,8 +824,10 @@ class Experiment:
             f.close()
         except EOFError as eof:
             self.util.error(f"can't open file {filename}: {eof}")
+        tmp_dict.pop("context", None)
         self.__dict__.update(tmp_dict)
-        glob_conf.set_labels(self.labels)
+        self.context = context
+        self.context.labels = self.labels
 
     def save(self, filename):
         if self.runmgr.modelrunner.model.is_ann():
@@ -806,7 +837,9 @@ class Experiment:
             )
         try:
             f = open(filename, "wb")
-            pickle.dump(self.__dict__, f)
+            state = self.__dict__.copy()
+            state.pop("context", None)
+            pickle.dump(state, f)
             f.close()
             save_checksum(filename)
         except (TypeError, AttributeError) as error:
@@ -827,7 +860,9 @@ class Experiment:
                 if hasattr(inner, "model_loaded"):
                     inner.model_loaded = False
             f = open(filename, "wb")
-            pickle.dump(self.__dict__, f)
+            state = self.__dict__.copy()
+            state.pop("context", None)
+            pickle.dump(state, f)
             f.close()
             save_checksum(filename)
             self.util.warn(

--- a/nkululeko/experiment_context.py
+++ b/nkululeko/experiment_context.py
@@ -1,0 +1,91 @@
+"""Experiment-scoped runtime state.
+
+The context is passed through Nkululeko's orchestration objects.  The
+``glob_conf`` module retains a compatibility adapter for third-party code that
+has not yet migrated to this API.
+"""
+
+import types
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+from functools import wraps
+
+
+@dataclass
+class ExperimentContext:
+    """Mutable runtime state owned by one experiment execution."""
+
+    config: object = None
+    label_encoder: object = None
+    util: object = None
+    module: object = None
+    report: object = None
+    labels: object = None
+    target: object = None
+    split3: bool = False
+    got_speaker: bool = False
+
+
+_default_context = ExperimentContext()
+_current_context = ContextVar("nkululeko_experiment_context", default=_default_context)
+
+
+def get_context():
+    """Return the context active in this execution context."""
+    return _current_context.get()
+
+
+def set_context(context):
+    """Make *context* active until another context is selected."""
+    _current_context.set(context)
+
+
+@contextmanager
+def use_context(context):
+    """Make *context* active for the duration of the with block."""
+    token = _current_context.set(context)
+    try:
+        yield context
+    finally:
+        _current_context.reset(token)
+
+
+def bind_experiment_context(cls):
+    """Bind an object's methods to its ``context`` attribute.
+
+    The binding makes nested legacy integrations observe the correct context
+    while those integrations are migrated to explicit dependencies.
+    """
+
+    def bind(method):
+        @wraps(method)
+        def wrapped(self, *args, **kwargs):
+            context = getattr(self, "context", None)
+            if context is None:
+                return method(self, *args, **kwargs)
+            with use_context(context):
+                return method(self, *args, **kwargs)
+
+        return wrapped
+
+    for name, value in vars(cls).items():
+        if not name.startswith("__") and isinstance(value, types.FunctionType):
+            setattr(cls, name, bind(value))
+    return cls
+
+
+class ContextAware:
+    """Provide a compatibility fallback for partially initialized objects."""
+
+    @property
+    def context(self):
+        context = getattr(self, "_context", None)
+        if context is not None:
+            return context
+        util = getattr(self, "util", None)
+        return getattr(util, "context", get_context())
+
+    @context.setter
+    def context(self, context):
+        self._context = context

--- a/nkululeko/feat_extract/feats_agender.py
+++ b/nkululeko/feat_extract/feats_agender.py
@@ -9,7 +9,6 @@ import audonnx
 import numpy as np
 import torch
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -66,7 +65,7 @@ class AgenderSet(Featureset):
             self.df = hidden_states.process_index(self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                self.context.config["DATA"]["needs_feature_extraction"] = "False"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_agender_agender.py
+++ b/nkululeko/feat_extract/feats_agender_agender.py
@@ -7,7 +7,6 @@ import audonnx
 import numpy as np
 import torch
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -70,7 +69,7 @@ class Agender_agenderSet(Featureset):
             self.df = logits.process_index(self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                self.context.config["DATA"]["needs_feature_extraction"] = "False"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_analyser.py
+++ b/nkululeko/feat_extract/feats_analyser.py
@@ -11,7 +11,7 @@ from sklearn.inspection import permutation_importance
 from sklearn.linear_model import LinearRegression, LogisticRegression
 from sklearn.tree import DecisionTreeClassifier, DecisionTreeRegressor
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.plots import Plots
 from nkululeko.reporting.defines import Header
 from nkululeko.reporting.report_item import ReportItem
@@ -19,9 +19,10 @@ from nkululeko.utils.stats import normalize
 from nkululeko.utils.util import Util
 
 
-class FeatureAnalyser:
-    def __init__(self, label, df_labels, df_features):
-        self.util = Util("feats_analyser")
+class FeatureAnalyser(ContextAware):
+    def __init__(self, label, df_labels, df_features, context=None):
+        self.util = Util("feats_analyser", context=context)
+        self.context = self.util.context
         self.target = self.util.config_val("DATA", "target", "emotion")
         self.labels = df_labels[self.target]
         # self.labels = df_labels["class_label"]
@@ -34,7 +35,7 @@ class FeatureAnalyser:
 
         self.features = df_features
         self.label = label
-        self.plots = Plots()
+        self.plots = Plots(context=self.context)
 
     def _get_importance(self, model, permutation):
         """Fit model and return feature importances, with pickle caching.
@@ -94,7 +95,7 @@ class FeatureAnalyser:
         """Plot decision tree if configured."""
         if self.util.config_val_bool("EXPL", "plot_tree", False):
             model.fit(self.features, self.labels)
-            plots = Plots()
+            plots = Plots(context=self.context)
             plots.plot_tree(model, self.features)
 
     def analyse_shap(self, model):
@@ -121,7 +122,7 @@ class FeatureAnalyser:
             explainer = shap.Explainer(
                 model_func,
                 self.features,
-                output_names=glob_conf.labels,
+                output_names=self.context.labels,
                 feature_names=self.features.columns.tolist(),
                 algorithm="permutation",
                 npermutations=5,
@@ -347,7 +348,7 @@ class FeatureAnalyser:
         caption = "Feature importance"
         if permutation:
             caption += " based on permutation of features."
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 caption,

--- a/nkululeko/feat_extract/feats_ast.py
+++ b/nkululeko/feat_extract/feats_ast.py
@@ -7,7 +7,6 @@ import torch
 import torchaudio
 from transformers import ASTModel, AutoProcessor
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -59,7 +58,7 @@ class Ast(Featureset):
             self.df = self._extract_embeddings_with_error_handling(_load_file)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_auddim.py
+++ b/nkululeko/feat_extract/feats_auddim.py
@@ -7,7 +7,6 @@ import audonnx
 import numpy as np
 import torch
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -61,7 +60,7 @@ class AuddimSet(Featureset):
             self.df = logits.process_index(self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                self.context.config["DATA"]["needs_feature_extraction"] = "False"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_audmodel.py
+++ b/nkululeko/feat_extract/feats_audmodel.py
@@ -15,7 +15,6 @@ import audmodel
 import audonnx
 
 from nkululeko.feat_extract.featureset import Featureset
-import nkululeko.glob_conf as glob_conf
 
 
 class AudmodelSet(Featureset):
@@ -147,7 +146,7 @@ class AudmodelSet(Featureset):
             self.df = df
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                self.context.config["DATA"]["needs_feature_extraction"] = "False"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_audwav2vec2.py
+++ b/nkululeko/feat_extract/feats_audwav2vec2.py
@@ -10,7 +10,6 @@ import numpy as np
 import torch
 import uuid
 from tqdm import tqdm
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -84,7 +83,7 @@ class Audwav2vec2Set(Featureset):
             self.df = df
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                self.context.config["DATA"]["needs_feature_extraction"] = "False"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_bert.py
+++ b/nkululeko/feat_extract/feats_bert.py
@@ -6,7 +6,6 @@ import transformers
 import torch
 
 from nkululeko.feat_extract.featureset import Featureset
-import nkululeko.glob_conf as glob_conf
 
 
 class Bert(Featureset):
@@ -73,7 +72,7 @@ class Bert(Featureset):
             # print(f"df shape: {self.df.shape}")
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_clap.py
+++ b/nkululeko/feat_extract/feats_clap.py
@@ -5,7 +5,6 @@ import os
 import audiofile
 import laion_clap
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -49,7 +48,7 @@ class ClapSet(Featureset):
             self.df = self._extract_embeddings_with_error_handling(_load_file)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_cqcc.py
+++ b/nkululeko/feat_extract/feats_cqcc.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import SAMPLING_RATE
 from nkululeko.feat_extract.feats_audio import read_indexed_audio, series_to_float_df
 from nkululeko.feat_extract.featureset import Featureset
@@ -118,7 +117,7 @@ class CqccSet(Featureset):
             self.df = self._extract_index(self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_emotion2vec.py
+++ b/nkululeko/feat_extract/feats_emotion2vec.py
@@ -13,7 +13,6 @@ import torch
 import torchaudio
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -92,7 +91,7 @@ class Emotion2vec(Featureset):
             self.df = pd.DataFrame(emb_series.values.tolist(), index=self.data_df.index)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_hubert.py
+++ b/nkululeko/feat_extract/feats_hubert.py
@@ -11,7 +11,6 @@ import torch
 import torchaudio
 from transformers import HubertModel, Wav2Vec2FeatureExtractor
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -78,7 +77,7 @@ class Hubert(Featureset):
             self.df = self._extract_embeddings_with_error_handling(_load_file)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_lfcc.py
+++ b/nkululeko/feat_extract/feats_lfcc.py
@@ -5,7 +5,6 @@ import os
 import numpy as np
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import SAMPLING_RATE
 from nkululeko.feat_extract.feats_audio import read_indexed_audio, series_to_float_df
 from nkululeko.feat_extract.featureset import Featureset
@@ -128,7 +127,7 @@ class LfccSet(Featureset):
             self.df = self._extract_index(self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_mld.py
+++ b/nkululeko/feat_extract/feats_mld.py
@@ -3,7 +3,6 @@ import os
 import sys
 from typing import Optional
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -68,7 +67,7 @@ class MLD_set(Featureset):
 
         try:
             # use only samples that have a minimum number of syllables
-            min_syls = int(glob_conf.config["FEATS"]["min_syls"])
+            min_syls = int(self.context.config["FEATS"]["min_syls"])
             self.df = self.df[self.df["hld_nSyl"] >= min_syls]
         except KeyError:
             pass

--- a/nkululeko/feat_extract/feats_mos.py
+++ b/nkululeko/feat_extract/feats_mos.py
@@ -21,7 +21,6 @@ from torchaudio.pipelines import SQUIM_SUBJECTIVE
 from torchaudio.utils import _download_asset
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -70,7 +69,7 @@ class MosSet(Featureset):
             self.df.columns = ["mos"]
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_opensmile.py
+++ b/nkululeko/feat_extract/feats_opensmile.py
@@ -10,7 +10,6 @@ import opensmile
 import pandas as pd
 import numpy as np
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -136,7 +135,7 @@ class Opensmileset(Featureset):
 
                 # Update configuration to avoid re-extraction
                 try:
-                    glob_conf.config["DATA"]["needs_feature_extraction"] = "False"
+                    self.context.config["DATA"]["needs_feature_extraction"] = "False"
                 except KeyError:
                     pass
 
@@ -205,7 +204,7 @@ class Opensmileset(Featureset):
                 import ast
 
                 feature_list = ast.literal_eval(
-                    glob_conf.config["FEATS"]["os.features"]
+                    self.context.config["FEATS"]["os.features"]
                 )
             except (KeyError, ValueError, SyntaxError):
                 self.util.debug("No feature list specified, using all features")

--- a/nkululeko/feat_extract/feats_praat.py
+++ b/nkululeko/feat_extract/feats_praat.py
@@ -4,7 +4,6 @@ import os
 import numpy as np
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract import feats_praat_core
 from nkululeko.feat_extract.featureset import Featureset
 
@@ -37,7 +36,7 @@ class PraatSet(Featureset):
 
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_snr.py
+++ b/nkululeko/feat_extract/feats_snr.py
@@ -9,7 +9,6 @@ import audiofile
 import pandas as pd
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.autopredict.estimate_snr import SNREstimator
 from nkululeko.feat_extract.featureset import Featureset
 
@@ -48,7 +47,7 @@ class SnrSet(Featureset):
             self.df.columns = ["snr"]
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_spectra.py
+++ b/nkululeko/feat_extract/feats_spectra.py
@@ -17,7 +17,6 @@ import torchaudio.transforms as T
 from PIL import Image, ImageOps
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import SAMPLING_RATE
 from nkululeko.feat_extract.featureset import Featureset
 
@@ -57,7 +56,7 @@ class Spectraloader(Featureset):
             self.df = pd.DataFrame(images, index=self.data_df.index)
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_spkrec.py
+++ b/nkululeko/feat_extract/feats_spkrec.py
@@ -12,7 +12,6 @@ import torch
 import torchaudio
 from speechbrain.inference import EncoderClassifier
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 # from transformers import HubertModel, Wav2Vec2FeatureExtractor
@@ -71,7 +70,7 @@ class Spkrec(Featureset):
             self.util.debug(f"df shape: {self.df.shape}")
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_sptk.py
+++ b/nkululeko/feat_extract/feats_sptk.py
@@ -13,7 +13,6 @@ import numpy as np
 import pandas as pd
 import torch
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 from nkululeko.feat_extract import feats_sptk_core
 
@@ -87,7 +86,7 @@ class SptkSet(Featureset):
 
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_squim.py
+++ b/nkululeko/feat_extract/feats_squim.py
@@ -19,7 +19,6 @@ import torch
 import torchaudio
 from torchaudio.pipelines import SQUIM_OBJECTIVE
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -72,7 +71,7 @@ class SquimSet(Featureset):
                 self.df.columns = ["pesq", "sdr", "stoi"]
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_textclassifier.py
+++ b/nkululeko/feat_extract/feats_textclassifier.py
@@ -6,7 +6,6 @@ import transformers
 import torch
 
 from nkululeko.feat_extract.featureset import Featureset
-import nkululeko.glob_conf as glob_conf
 
 
 class TextClassifier(Featureset):
@@ -77,7 +76,7 @@ class TextClassifier(Featureset):
             self.df.columns = col_names
             self.util.write_store(self.df, storage, store_format)
             try:
-                glob_conf.config["FEATS"]["needs_feature_extraction"] = "false"
+                self.context.config["FEATS"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_trill.py
+++ b/nkululeko/feat_extract/feats_trill.py
@@ -8,7 +8,6 @@ import tensorflow as tf
 import tensorflow_hub as hub
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 # Import TF 2.X and make sure we're running eager.
@@ -60,7 +59,7 @@ class TRILLset(Featureset):
             self.df = pd.DataFrame(emb_series.values.tolist(), index=self.data_df.index)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_wav2vec2.py
+++ b/nkululeko/feat_extract/feats_wav2vec2.py
@@ -16,7 +16,6 @@ from transformers import Wav2Vec2FeatureExtractor
 from transformers import Wav2Vec2Model
 
 from nkululeko.feat_extract.featureset import Featureset
-import nkululeko.glob_conf as glob_conf
 
 
 class Wav2vec2(Featureset):
@@ -85,7 +84,7 @@ class Wav2vec2(Featureset):
             self.df = self._extract_embeddings_with_error_handling(_load_file)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_wavlm.py
+++ b/nkululeko/feat_extract/feats_wavlm.py
@@ -12,7 +12,6 @@ from transformers import Wav2Vec2FeatureExtractor
 from transformers import WavLMModel
 
 from nkululeko.feat_extract.featureset import Featureset
-import nkululeko.glob_conf as glob_conf
 
 
 class Wavlm(Featureset):
@@ -86,7 +85,7 @@ class Wavlm(Featureset):
             self.df = self._extract_embeddings_with_error_handling(_load_file)
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/feats_whisper.py
+++ b/nkululeko/feat_extract/feats_whisper.py
@@ -7,7 +7,6 @@ import pandas as pd
 import torch
 from transformers import AutoFeatureExtractor, WhisperModel
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.feat_extract.featureset import Featureset
 
 
@@ -75,7 +74,7 @@ class Whisper(Featureset):
             # print(f"df shape: {self.df.shape}")
             self.df.to_pickle(storage)
             try:
-                glob_conf.config["DATA"]["needs_feature_extraction"] = "false"
+                self.context.config["DATA"]["needs_feature_extraction"] = "false"
             except KeyError:
                 pass
         else:

--- a/nkululeko/feat_extract/featureset.py
+++ b/nkululeko/feat_extract/featureset.py
@@ -3,17 +3,17 @@ import ast
 
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.utils.util import Util
 
 
-class Featureset:
+class Featureset(ContextAware):
     name = ""  # designation
     df = None  # pandas dataframe to store the features
     # (and indexed with the data from the sets)
     data_df = None  # dataframe to get audio paths
 
-    def __init__(self, name, data_df, feats_type):
+    def __init__(self, name, data_df, feats_type, context=None):
         """Constructor.
 
         Args:
@@ -23,7 +23,8 @@ class Featureset:
         """
         self.name = name
         self.data_df = data_df
-        self.util = Util("featureset")
+        self.util = Util("featureset", context=context)
+        self.context = self.util.context
         self.feats_type = feats_type
         self.n_jobs = int(self.util.config_val("MODEL", "n_jobs", "8"))
 
@@ -84,7 +85,9 @@ class Featureset:
         self.df = self.util.filter_filepath(self.data_df, self.df)
         try:
             # use only some features
-            selected_features = ast.literal_eval(glob_conf.config["FEATS"]["features"])
+            selected_features = ast.literal_eval(
+                self.context.config["FEATS"]["features"]
+            )
             self.util.debug(f"selecting features: {selected_features}")
             sel_feats_df = pd.DataFrame()
             hit = False

--- a/nkululeko/feat_extract/featureset.py
+++ b/nkululeko/feat_extract/featureset.py
@@ -3,7 +3,7 @@ import ast
 
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.utils.util import Util
 
 # Exceptions expected from per-file feature extraction (bad/corrupt audio,
@@ -12,13 +12,13 @@ from nkululeko.utils.util import Util
 EXTRACTION_ERRORS = (IOError, OSError, RuntimeError, ValueError, AssertionError)
 
 
-class Featureset:
+class Featureset(ContextAware):
     name = ""  # designation
     df = None  # pandas dataframe to store the features
     # (and indexed with the data from the sets)
     data_df = None  # dataframe to get audio paths
 
-    def __init__(self, name, data_df, feats_type):
+    def __init__(self, name, data_df, feats_type, context=None):
         """Constructor.
 
         Args:
@@ -28,7 +28,8 @@ class Featureset:
         """
         self.name = name
         self.data_df = data_df
-        self.util = Util("featureset")
+        self.util = Util("featureset", context=context)
+        self.context = self.util.context
         self.feats_type = feats_type
         self.n_jobs = int(self.util.config_val("MODEL", "n_jobs", "8"))
 
@@ -125,7 +126,9 @@ class Featureset:
         self.df = self.util.filter_filepath(self.data_df, self.df)
         try:
             # use only some features
-            selected_features = ast.literal_eval(glob_conf.config["FEATS"]["features"])
+            selected_features = ast.literal_eval(
+                self.context.config["FEATS"]["features"]
+            )
             self.util.debug(f"selecting features: {selected_features}")
             sel_feats_df = pd.DataFrame()
             hit = False

--- a/nkululeko/feature_extractor.py
+++ b/nkululeko/feature_extractor.py
@@ -6,10 +6,11 @@ Extract acoustic features using several feature extractors
 
 import pandas as pd
 
+from nkululeko.experiment_context import ContextAware, use_context
 from nkululeko.utils.util import Util
 
 
-class FeatureExtractor:
+class FeatureExtractor(ContextAware):
     """Extract acoustic features from audio samples.
 
     Extract acoustic features using several feature extractors (appends the features column-wise).
@@ -28,11 +29,14 @@ class FeatureExtractor:
     df = None
     data_df = None  # dataframe to get audio paths
 
-    def __init__(self, data_df, feats_types, data_name, feats_designation):
+    def __init__(
+        self, data_df, feats_types, data_name, feats_designation, context=None
+    ):
         self.data_df = data_df
         self.data_name = data_name
         self.feats_types = feats_types
-        self.util = Util("feature_extractor")
+        self.util = Util("feature_extractor", context=context)
+        self.context = self.util.context
         self.feats_designation = feats_designation
 
     def extract(self):
@@ -54,9 +58,10 @@ class FeatureExtractor:
         feat_extractor_class = self._get_feat_extractor_class(feats_type)
         if feat_extractor_class is None:
             self.util.error(f"unknown feats_type: {feats_type}")
-        return feat_extractor_class(
-            f"{store_name}_{self.feats_designation}", self.data_df, feats_type
-        )
+        with use_context(self.context):
+            return feat_extractor_class(
+                f"{store_name}_{self.feats_designation}", self.data_df, feats_type
+            )
 
     def _get_feat_extractor_class(self, feats_type):
         if feats_type == "os":

--- a/nkululeko/filter_data.py
+++ b/nkululeko/filter_data.py
@@ -3,13 +3,12 @@ import ast
 import audformat
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.utils.util import Util
 
 
 class DataFilter:
-    def __init__(self, df):
-        self.util = Util("datafilter")
+    def __init__(self, df, context=None):
+        self.util = Util("datafilter", context=context)
         self.df = df.copy()
         self.util.copy_flags(df, self.df)
 
@@ -196,11 +195,11 @@ def limit_speakers(df, max=20):
     return df_ret
 
 
-def filter_min_dur(df, min_dur):
+def filter_min_dur(df, min_dur, util=None):
     """remove all samples less than min_dur duration"""
     df_ret = df.copy()
     if not isinstance(df.index, pd.MultiIndex):
-        glob_conf.util.debug(
+        (util or Util("filter_min_dur")).debug(
             "converting file index to multi index, this might take a while..."
         )
         df_ret.index = audformat.utils.to_segmented_index(df.index, allow_nat=False)
@@ -216,11 +215,11 @@ def filter_min_dur(df, min_dur):
     return df_ret
 
 
-def filter_max_dur(df, max_dur):
+def filter_max_dur(df, max_dur, util=None):
     """remove all samples less than min_dur duration"""
     df_ret = df.copy()
     if not isinstance(df.index, pd.MultiIndex):
-        glob_conf.util.debug(
+        (util or Util("filter_max_dur")).debug(
             "converting file index to multi index, this might take a while..."
         )
         df_ret.index = audformat.utils.to_segmented_index(df.index, allow_nat=False)

--- a/nkululeko/glob_conf.py
+++ b/nkululeko/glob_conf.py
@@ -1,57 +1,111 @@
-# glob_conf.py
+"""Compatibility facade for experiment-scoped shared state.
 
-# Initialize global variables
-config = None
-label_encoder = None
-util = None
-module = None
-report = None
-labels = None
-target = None
-split3 = False
-got_speaker = False
+New code should receive an :class:`ExperimentContext` explicitly.  The module
+attributes remain available while existing components are migrated.
+"""
+
+import sys
+import types
+
+from nkululeko.experiment_context import (
+    ExperimentContext,
+    bind_experiment_context,
+    get_context,
+    set_context,
+    use_context,
+)
+
+
+_STATE_FIELDS = frozenset(
+    {
+        "config",
+        "label_encoder",
+        "util",
+        "module",
+        "report",
+        "labels",
+        "target",
+        "split3",
+        "got_speaker",
+    }
+)
+
+__all__ = [
+    "ExperimentContext",
+    "bind_experiment_context",
+    "get_context",
+    "init_config",
+    "set_context",
+    "set_got_speaker",
+    "set_label_encoder",
+    "set_labels",
+    "set_module",
+    "set_report",
+    "set_split3",
+    "set_target",
+    "set_util",
+    "use_context",
+    "config",
+    "label_encoder",
+    "util",
+    "module",
+    "report",
+    "labels",
+    "target",
+    "split3",
+    "got_speaker",
+]
 
 
 def init_config(config_obj):
-    global config
-    config = config_obj
+    get_context().config = config_obj
 
 
 def set_label_encoder(encoder):
-    global label_encoder
-    label_encoder = encoder
+    get_context().label_encoder = encoder
 
 
 def set_util(util_obj):
-    global util
-    util = util_obj
+    get_context().util = util_obj
 
 
 def set_module(module_obj):
-    global module
-    module = module_obj
+    get_context().module = module_obj
 
 
 def set_report(report_obj):
-    global report
-    report = report_obj
+    get_context().report = report_obj
 
 
 def set_labels(labels_obj):
-    global labels
-    labels = labels_obj
+    get_context().labels = labels_obj
 
 
 def set_target(target_obj):
-    global target
-    target = target_obj
+    get_context().target = target_obj
 
 
 def set_split3(split3_obj):
-    global split3
-    split3 = split3_obj
+    get_context().split3 = split3_obj
 
 
 def set_got_speaker(got_speaker_obj):
-    global got_speaker
-    got_speaker = got_speaker_obj
+    get_context().got_speaker = got_speaker_obj
+
+
+class _ContextAwareModule(types.ModuleType):
+    """Route legacy module attributes to the active experiment context."""
+
+    def __getattribute__(self, name):
+        if name in _STATE_FIELDS:
+            return getattr(get_context(), name)
+        return super().__getattribute__(name)
+
+    def __setattr__(self, name, value):
+        if name in _STATE_FIELDS:
+            setattr(get_context(), name, value)
+            return
+        super().__setattr__(name, value)
+
+
+sys.modules[__name__].__class__ = _ContextAwareModule

--- a/nkululeko/infer.py
+++ b/nkululeko/infer.py
@@ -26,7 +26,7 @@ import tempfile
 import audformat
 import pandas as pd
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ExperimentContext, set_context
 from nkululeko.constants import AUDIO_EXTS, VERSION
 from nkululeko.utils.files import safe_path
 from nkululeko.utils.util import Util
@@ -155,8 +155,8 @@ def _load_bundle(bundle_dir):
     }
 
 
-def _setup_glob_conf(bundle):
-    """Set up glob_conf with the bundle's inference config."""
+def _setup_context(bundle):
+    """Create the context used for bundle inference."""
     config = bundle["config"]
     # Ensure required sections exist
     for section in ("EXP", "DATA", "FEATS", "MODEL"):
@@ -173,15 +173,13 @@ def _setup_glob_conf(bundle):
     if "databases" not in config["DATA"]:
         config["DATA"]["databases"] = "['adhoc']"
 
-    glob_conf.init_config(config)
-    glob_conf.set_module("infer")
-
-    if bundle["label_encoder"] is not None:
-        glob_conf.set_label_encoder(bundle["label_encoder"])
-
+    context = ExperimentContext(config=config, module="infer")
+    context.label_encoder = bundle["label_encoder"]
     labels = bundle["manifest"].get("labels", None)
     if labels is not None:
-        glob_conf.set_labels(labels)
+        context.labels = labels
+    set_context(context)
+    return context
 
 
 def _extract_features(files, bundle, util):
@@ -206,10 +204,12 @@ def _extract_features(files, bundle, util):
     feats_type = util.config_val_list("FEATS", "type", ["os"])
 
     # Disable feature caching for inference
-    glob_conf.config["FEATS"]["no_reuse"] = "True"
-    glob_conf.config["FEATS"]["needs_feature_extraction"] = "True"
+    util.context.config["FEATS"]["no_reuse"] = "True"
+    util.context.config["FEATS"]["needs_feature_extraction"] = "True"
 
-    feature_extractor = FeatureExtractor(df, feats_type, "infer", "test")
+    feature_extractor = FeatureExtractor(
+        df, feats_type, "infer", "test", context=util.context
+    )
     feats = feature_extractor.extract()
 
     return feats
@@ -398,8 +398,8 @@ def infer_from_bundle(
         pd.DataFrame with prediction results.
     """
     bundle = _load_bundle(bundle_dir)
-    _setup_glob_conf(bundle)
-    util = Util("infer", has_config=True)
+    context = _setup_context(bundle)
+    util = Util("infer", has_config=True, context=context)
     util.debug(f"nkululeko {VERSION}: infer from bundle {bundle_dir}")
 
     manifest = bundle["manifest"]

--- a/nkululeko/infer.py
+++ b/nkululeko/infer.py
@@ -26,7 +26,7 @@ import tempfile
 import audformat
 import pandas as pd
 
-from nkululeko.experiment_context import ExperimentContext, set_context
+from nkululeko.experiment_context import ExperimentContext, use_context
 from nkululeko.constants import AUDIO_EXTS, VERSION
 from nkululeko.utils.files import safe_path
 from nkululeko.utils.util import Util
@@ -156,7 +156,12 @@ def _load_bundle(bundle_dir):
 
 
 def _setup_context(bundle):
-    """Create the context used for bundle inference."""
+    """Build the experiment context used for bundle inference.
+
+    Does not make the context active — callers should run inference inside
+    `with use_context(context):` so the active context is scoped to the
+    inference call rather than leaking into unrelated process-wide state.
+    """
     config = bundle["config"]
     # Ensure required sections exist
     for section in ("EXP", "DATA", "FEATS", "MODEL"):
@@ -178,7 +183,6 @@ def _setup_context(bundle):
     labels = bundle["manifest"].get("labels", None)
     if labels is not None:
         context.labels = labels
-    set_context(context)
     return context
 
 
@@ -399,24 +403,29 @@ def infer_from_bundle(
     """
     bundle = _load_bundle(bundle_dir)
     context = _setup_context(bundle)
-    util = Util("infer", has_config=True, context=context)
-    util.debug(f"nkululeko {VERSION}: infer from bundle {bundle_dir}")
+    with use_context(context):
+        util = Util("infer", has_config=True, context=context)
+        util.debug(f"nkululeko {VERSION}: infer from bundle {bundle_dir}")
 
-    manifest = bundle["manifest"]
-    util.debug(
-        f"  task={manifest.get('task')}, target={manifest.get('target')}, "
-        f"model={manifest.get('model_type')}"
-    )
+        manifest = bundle["manifest"]
+        util.debug(
+            f"  task={manifest.get('task')}, target={manifest.get('target')}, "
+            f"model={manifest.get('model_type')}"
+        )
 
-    if files:
-        return _run_files(files, bundle, util, outfile)
-    elif folder:
-        return _run_folder(folder, bundle, util, outfile or "./bundle_predictions.csv")
-    elif list_path:
-        return _run_list(list_path, bundle, util, outfile or "./bundle_predictions.csv")
-    else:
-        print("ERROR: provide one of --file, --folder, or --list", file=sys.stderr)
-        sys.exit(1)
+        if files:
+            return _run_files(files, bundle, util, outfile)
+        elif folder:
+            return _run_folder(
+                folder, bundle, util, outfile or "./bundle_predictions.csv"
+            )
+        elif list_path:
+            return _run_list(
+                list_path, bundle, util, outfile or "./bundle_predictions.csv"
+            )
+        else:
+            print("ERROR: provide one of --file, --folder, or --list", file=sys.stderr)
+            sys.exit(1)
 
 
 def _build_parser():

--- a/nkululeko/modelrunner.py
+++ b/nkululeko/modelrunner.py
@@ -2,8 +2,8 @@
 
 import ast
 
-from nkululeko import glob_conf
 from nkululeko.balance import DataBalancer
+from nkululeko.experiment_context import ContextAware, use_context
 from nkululeko.utils.util import Util
 
 # Fallback type-based heuristics used when a model instance is not yet available
@@ -71,11 +71,18 @@ def _check_task_capability(
         )
 
 
-class Modelrunner:
+class Modelrunner(ContextAware):
     """Class to model one run."""
 
     def __init__(
-        self, df_train, df_test, feats_train, feats_test, run, split_name="test"
+        self,
+        df_train,
+        df_test,
+        feats_train,
+        feats_test,
+        run,
+        split_name="test",
+        context=None,
     ):
         """Constructor setting up the dataframes.
 
@@ -93,13 +100,15 @@ class Modelrunner:
             feats_train,
             feats_test,
         )
-        self.util = Util("modelrunner")
+        self.util = Util("modelrunner", context=context)
+        self.context = self.util.context
         self.run = run
         self.split_name = split_name.upper()  # Store as uppercase for display
-        self.target = glob_conf.config["DATA"]["target"]
+        self.target = self.context.config["DATA"]["target"]
         # intialize a new model
-        model_type = glob_conf.config["MODEL"]["type"]
-        self._select_model(model_type)
+        model_type = self.context.config["MODEL"]["type"]
+        with use_context(self.context):
+            self._select_model(model_type)
         # Initialize best_performance based on metric direction
         if self.util.high_is_good():
             self.best_performance = 0
@@ -116,7 +125,7 @@ class Modelrunner:
         if not self.model.is_ann() and epoch_num > 1:
             self.util.warn(f"setting epoch num to 1 (was {epoch_num}) if model not ANN")
             epoch_num = 1
-            glob_conf.config["EXP"]["epochs"] = "1"
+            self.context.config["EXP"]["epochs"] = "1"
         patience = self.util.config_val("MODEL", "patience", False)
         patience_counter = -1
         if self.util.high_is_good():
@@ -371,7 +380,9 @@ class Modelrunner:
             )
 
             # Initialize the data balancer with configurable random state
-            balancer = DataBalancer(random_state=random_state)
+            balancer = DataBalancer(
+                random_state=random_state, context=self.context
+            )
 
             # Apply balancing
             self.df_train, self.feats_train = balancer.balance_features(

--- a/nkululeko/modelrunner.py
+++ b/nkululeko/modelrunner.py
@@ -2,16 +2,23 @@
 
 import ast
 
-from nkululeko import glob_conf
 from nkululeko.utils.util import Util
 from nkululeko.balance import DataBalancer
+from nkululeko.experiment_context import ContextAware, use_context
 
 
-class Modelrunner:
+class Modelrunner(ContextAware):
     """Class to model one run."""
 
     def __init__(
-        self, df_train, df_test, feats_train, feats_test, run, split_name="test"
+        self,
+        df_train,
+        df_test,
+        feats_train,
+        feats_test,
+        run,
+        split_name="test",
+        context=None,
     ):
         """Constructor setting up the dataframes.
 
@@ -29,13 +36,15 @@ class Modelrunner:
             feats_train,
             feats_test,
         )
-        self.util = Util("modelrunner")
+        self.util = Util("modelrunner", context=context)
+        self.context = self.util.context
         self.run = run
         self.split_name = split_name.upper()  # Store as uppercase for display
-        self.target = glob_conf.config["DATA"]["target"]
+        self.target = self.context.config["DATA"]["target"]
         # intialize a new model
-        model_type = glob_conf.config["MODEL"]["type"]
-        self._select_model(model_type)
+        model_type = self.context.config["MODEL"]["type"]
+        with use_context(self.context):
+            self._select_model(model_type)
         # Initialize best_performance based on metric direction
         if self.util.high_is_good():
             self.best_performance = 0
@@ -52,7 +61,7 @@ class Modelrunner:
         if not self.model.is_ann() and epoch_num > 1:
             self.util.warn(f"setting epoch num to 1 (was {epoch_num}) if model not ANN")
             epoch_num = 1
-            glob_conf.config["EXP"]["epochs"] = "1"
+            self.context.config["EXP"]["epochs"] = "1"
         patience = self.util.config_val("MODEL", "patience", False)
         patience_counter = -1
         if self.util.high_is_good():
@@ -304,7 +313,9 @@ class Modelrunner:
             )
 
             # Initialize the data balancer with configurable random state
-            balancer = DataBalancer(random_state=random_state)
+            balancer = DataBalancer(
+                random_state=random_state, context=self.context
+            )
 
             # Apply balancing
             self.df_train, self.feats_train = balancer.balance_features(

--- a/nkululeko/models/model.py
+++ b/nkululeko/models/model.py
@@ -10,16 +10,16 @@ import sklearn.utils
 from joblib import parallel_backend
 from sklearn.model_selection import GridSearchCV, LeaveOneGroupOut, StratifiedKFold
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.reporting.reporter import Reporter
 from nkululeko.utils.pickle_integrity import save_checksum, verify_checksum
 from nkululeko.utils.util import Util
 
 
-class Model:
+class Model(ContextAware):
     """Generic model class for linear (non-neural) algorithms."""
 
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor taking the configuration and all dataframes."""
         self.name = "undefined"
         self.df_train, self.df_test, self.feats_train, self.feats_test = (
@@ -29,7 +29,8 @@ class Model:
             feats_test,
         )
         self.model_type = "classic"
-        self.util = Util("model")
+        self.util = Util("model", context=context)
+        self.context = self.util.context
         self.target = self.util.config_val("DATA", "target", "emotion")
         self.run = 0
         self.epoch = 0
@@ -149,7 +150,13 @@ class Model:
             truth_x = feats.iloc[test_index].to_numpy()
             truth_y = targets[test_index]
             predict_y = self.clf.predict(truth_x)
-            report = Reporter(truth_y.astype(float), predict_y, self.run, self.epoch)
+            report = Reporter(
+                truth_y.astype(float),
+                predict_y,
+                self.run,
+                self.epoch,
+                context=self.context,
+            )
             self.util.debug(
                 f"result for fold {g_index}: {report.get_result().get_test_result()} "
             )
@@ -216,7 +223,13 @@ class Model:
             truth_x = feats.iloc[test_index].to_numpy()
             truth_y = targets.iloc[test_index]
             predict_y = self.clf.predict(truth_x)
-            report = Reporter(truth_y.astype(float), predict_y, self.run, self.epoch)
+            report = Reporter(
+                truth_y.astype(float),
+                predict_y,
+                self.run,
+                self.epoch,
+                context=self.context,
+            )
             result = report.get_result().get_test_result()
             self.util.debug(f"result for speaker group {g_index}: {result} ")
             results.append(float(report.get_result().test))
@@ -274,11 +287,11 @@ class Model:
                 tuning_params = ast.literal_eval(tuning_params)
                 tuned_params = {}
                 try:
-                    scoring = glob_conf.config["MODEL"]["scoring"]
+                    scoring = self.context.config["MODEL"]["scoring"]
                 except KeyError:
                     self.util.error("got tuning params but no scoring")
                 for param in tuning_params:
-                    values = ast.literal_eval(glob_conf.config["MODEL"][param])
+                    values = ast.literal_eval(self.context.config["MODEL"][param])
                     tuned_params[param] = values
                 self.util.debug(f"tuning on {tuned_params}")
                 self.clf = GridSearchCV(
@@ -338,7 +351,11 @@ class Model:
         self.feats_test = self._handle_model_nan(self.feats_test, "Model, test")
         if self.logo or self.xfoldx:
             report = Reporter(
-                self.truths.astype(float), self.preds, self.run, self.epoch
+                self.truths.astype(float),
+                self.preds,
+                self.run,
+                self.epoch,
+                context=self.context,
             )
             return report
         """Predict the whole eval feature set"""
@@ -350,6 +367,7 @@ class Model:
             self.run,
             self.epoch,
             probas=probas,
+            context=self.context,
         )
         report.print_probabilities()
         return report

--- a/nkululeko/models/model_adm.py
+++ b/nkululeko/models/model_adm.py
@@ -17,7 +17,6 @@ import pandas as pd
 import torch
 from sklearn.metrics import recall_score
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model
 from nkululeko.models.model_adm_core import DeepfakeADMModel
 from nkululeko.optimizers import (
@@ -34,7 +33,7 @@ class ADMModel(Model):
 
     is_classifier = True
 
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor, taking all dataframes.
 
         Args:
@@ -43,10 +42,10 @@ class ADMModel(Model):
             feats_train (pd.DataFrame): The train features.
             feats_test (pd.DataFrame): The test features.
         """
-        super().__init__(df_train, df_test, feats_train, feats_test)
+        super().__init__(df_train, df_test, feats_train, feats_test, context=context)
         super().set_model_type("ann")
         self.name = "adm"
-        self.target = glob_conf.config["DATA"]["target"]
+        self.target = self.context.config["DATA"]["target"]
 
         # Manual seed
         manual_seed = eval(self.util.config_val("MODEL", "random_seed", "False"))
@@ -55,7 +54,7 @@ class ADMModel(Model):
             torch.manual_seed(int(manual_seed))
 
         # Get labels and class number
-        labels = glob_conf.labels
+        labels = self.context.labels
         self.class_num = len(labels)
 
         # Device setup (needed before loss initialization)
@@ -385,7 +384,7 @@ class ADMModel(Model):
         proba_d = {}
         # Use all known classes from glob_conf to ensure both classes are always
         # present, even if the test set only contains one class.
-        classes = np.arange(len(glob_conf.labels))
+        classes = np.arange(len(self.context.labels))
 
         # Apply sigmoid to get probabilities; clean non-finite logits first
         logits_clean = torch.nan_to_num(logits, nan=0.0, posinf=10.0, neginf=-10.0)
@@ -418,7 +417,14 @@ class ADMModel(Model):
         )
         uar, _, _, _ = self.evaluate(self.model, self.trainloader, self.device)
         probas = self.get_probas(logits)
-        report = Reporter(truths, predictions, self.run, self.epoch, probas=probas)
+        report = Reporter(
+            truths,
+            predictions,
+            self.run,
+            self.epoch,
+            probas=probas,
+            context=self.context,
+        )
 
         if hasattr(self, "loss"):
             report.result.loss = self.loss
@@ -452,14 +458,14 @@ class ADMModel(Model):
         except (TypeError, ValueError):
             pass
 
-        label_encoder = getattr(glob_conf, "label_encoder", None)
+        label_encoder = self.context.label_encoder
         if label_encoder is not None:
             try:
                 return label_encoder.transform(labels).astype(float)
             except ValueError:
                 pass
 
-        label_names = list(glob_conf.labels or [])
+        label_names = list(self.context.labels or [])
         label_map = {label: index for index, label in enumerate(label_names)}
         unknown_labels = sorted(set(labels.dropna()) - set(label_map))
         if unknown_labels:

--- a/nkululeko/models/model_cnn.py
+++ b/nkululeko/models/model_cnn.py
@@ -17,7 +17,6 @@ from PIL import Image
 from sklearn.metrics import recall_score
 from torch.utils.data import Dataset
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model
 from nkululeko.optimizers import get_optimizer
 from nkululeko.reporting.reporter import Reporter
@@ -28,7 +27,7 @@ class CNNModel(Model):
 
     is_classifier = True
 
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor, taking all dataframes.
 
         Args:
@@ -37,11 +36,11 @@ class CNNModel(Model):
             feats_train (pd.DataFrame): The train features.
             feats_test (pd.DataFrame): The test features.
         """
-        super().__init__(df_train, df_test, feats_train, feats_test)
+        super().__init__(df_train, df_test, feats_train, feats_test, context=context)
         super().set_model_type("ann")
         self.name = "cnn"
-        self.target = glob_conf.target
-        labels = glob_conf.labels
+        self.target = self.context.target
+        labels = self.context.labels
         self.class_num = len(labels)
         # set up loss criterion
         self._setup_criterion()
@@ -49,7 +48,7 @@ class CNNModel(Model):
         # cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", "cpu")
         try:
-            layers_string = glob_conf.config["MODEL"]["layers"]
+            layers_string = self.context.config["MODEL"]["layers"]
         except KeyError as ke:
             self.util.error(f"Please provide MODEL layers: {ke}")
         self.util.debug(f"using layers {layers_string}")
@@ -188,7 +187,14 @@ class CNNModel(Model):
         )
         uar, _, _, _ = self.evaluate(self.model, self.trainloader, self.device)
         probas = self.get_probas(logits)
-        report = Reporter(truths, predictions, self.run, self.epoch, probas=probas)
+        report = Reporter(
+            truths,
+            predictions,
+            self.run,
+            self.epoch,
+            probas=probas,
+            context=self.context,
+        )
         try:
             report.result.loss = self.loss
         except AttributeError:  # if the model was loaded from disk the loss is unknown
@@ -224,7 +230,7 @@ class CNNModel(Model):
         name = f"{self.util.get_exp_name(only_train=True)}_{self.run}_{self.epoch:03d}.model"
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         self.store_path = dir + name
         drop = self.util.config_val("MODEL", "drop", False)
         if drop:
@@ -241,7 +247,7 @@ class CNNModel(Model):
             raise FileNotFoundError(f"Model file not found: {path}")
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         self.store_path = path
         drop = self.util.config_val("MODEL", "drop", False)
         if drop:

--- a/nkululeko/models/model_mlp.py
+++ b/nkululeko/models/model_mlp.py
@@ -7,7 +7,6 @@ import pandas as pd
 import torch
 from sklearn.metrics import recall_score
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model
 from nkululeko.optimizers import get_optimizer
 from nkululeko.reporting.reporter import Reporter
@@ -18,7 +17,7 @@ class MLPModel(Model):
 
     is_classifier = True
 
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor, taking all dataframes.
 
         Args:
@@ -27,15 +26,15 @@ class MLPModel(Model):
             feats_train (pd.DataFrame): The train features.
             feats_test (pd.DataFrame): The test features.
         """
-        super().__init__(df_train, df_test, feats_train, feats_test)
+        super().__init__(df_train, df_test, feats_train, feats_test, context=context)
         super().set_model_type("ann")
         self.name = "mlp"
-        self.target = glob_conf.config["DATA"]["target"]
+        self.target = self.context.config["DATA"]["target"]
         manual_seed = eval(self.util.config_val("MODEL", "random_seed", "False"))
         if manual_seed:
             self.util.debug(f"seeding random to {manual_seed}")
             torch.manual_seed(int(manual_seed))
-        labels = glob_conf.labels
+        labels = self.context.labels
         self.class_num = len(labels)
         # set up loss criterion
         self._setup_criterion()
@@ -45,7 +44,7 @@ class MLPModel(Model):
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
         try:
-            layers_string = glob_conf.config["MODEL"]["layers"]
+            layers_string = self.context.config["MODEL"]["layers"]
         except KeyError as ke:
             self.util.error(f"Please provide MODEL layers: {ke}")
         self.util.debug(f"using layers {layers_string}")
@@ -165,7 +164,14 @@ class MLPModel(Model):
         )
         uar, _, _, _ = self.evaluate(self.model, self.trainloader, self.device)
         probas = self.get_probas(logits)
-        report = Reporter(truths, predictions, self.run, self.epoch, probas=probas)
+        report = Reporter(
+            truths,
+            predictions,
+            self.run,
+            self.epoch,
+            probas=probas,
+            context=self.context,
+        )
         try:
             report.result.loss = self.loss
         except AttributeError:  # if the model was loaded from disk the loss is unknown
@@ -263,7 +269,7 @@ class MLPModel(Model):
         name = f"{self.util.get_exp_name(only_train=True)}_{self.run}_{self.epoch:03d}.model"
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         self.store_path = dir + name
         drop = self.util.config_val("MODEL", "drop", "False")
         if drop != "False":
@@ -296,7 +302,7 @@ class MLPModel(Model):
             raise FileNotFoundError(f"Model file not found: {path}")
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         self.store_path = path
         drop = self.util.config_val("MODEL", "drop", "False")
         if drop != "False":

--- a/nkululeko/models/model_mlp_regression.py
+++ b/nkululeko/models/model_mlp_regression.py
@@ -6,7 +6,6 @@ import numpy as np
 import torch
 from audmetric import concordance_cc, mean_absolute_error, mean_squared_error
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.losses.loss_ccc import ConcordanceCorCoeff
 from nkululeko.models.model import Model
 from nkululeko.optimizers import get_optimizer
@@ -18,13 +17,13 @@ class MLP_Reg_model(Model):
 
     is_classifier = False
 
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor taking the configuration and all dataframes"""
-        super().__init__(df_train, df_test, feats_train, feats_test)
+        super().__init__(df_train, df_test, feats_train, feats_test, context=context)
         self.name = "mlp_reg"
         super().set_model_type("ann")
-        self.target = glob_conf.config["DATA"]["target"]
-        labels = glob_conf.labels
+        self.target = self.context.config["DATA"]["target"]
+        labels = self.context.labels
         self.class_num = len(labels)
         # set up loss criterion
         criterion = self.util.config_val("MODEL", "loss", "mse")
@@ -47,7 +46,7 @@ class MLP_Reg_model(Model):
         # set up the model
         cuda = "cuda" if torch.cuda.is_available() else "cpu"
         self.device = self.util.config_val("MODEL", "device", cuda)
-        layers_string = glob_conf.config["MODEL"]["layers"]
+        layers_string = self.context.config["MODEL"]["layers"]
         self.util.debug(f"using layers {layers_string}")
         try:
             layers = ast.literal_eval(layers_string)
@@ -112,7 +111,11 @@ class MLP_Reg_model(Model):
         )
         result, _, _ = self.evaluate_model(self.model, self.trainloader, self.device)
         report = Reporter(
-            truths.numpy(), predictions.numpy(), None, self.run, self.epoch
+            truths.numpy(),
+            predictions.numpy(),
+            self.run,
+            self.epoch,
+            context=self.context,
         )
         try:
             report.result.loss = self.loss
@@ -246,7 +249,7 @@ class MLP_Reg_model(Model):
         name = f"{self.util.get_exp_name(only_train=True)}_{run}_{epoch:03d}.model"
         self.store_path = dir + name
         self.device = self.util.config_val("MODEL", "device", "cpu")
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         drop = self.util.config_val("MODEL", "drop", False)
         if drop:
             self.util.debug(f"training with dropout: {drop}")
@@ -264,7 +267,7 @@ class MLP_Reg_model(Model):
         if not Path(path).exists():
             raise FileNotFoundError(f"Model file not found: {path}")
         self.device = self.util.config_val("MODEL", "device", "cpu")
-        layers = ast.literal_eval(glob_conf.config["MODEL"]["layers"])
+        layers = ast.literal_eval(self.context.config["MODEL"]["layers"])
         self.store_path = path
         drop = self.util.config_val("MODEL", "drop", False)
         if drop:

--- a/nkululeko/models/model_tuned.py
+++ b/nkululeko/models/model_tuned.py
@@ -20,16 +20,15 @@ from transformers.models.wav2vec2.modeling_wav2vec2 import (
     Wav2Vec2PreTrainedModel,
 )
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.models.model import Model as BaseModel
 from nkululeko.reporting.reporter import Reporter
 from nkululeko.utils.pickle_integrity import verify_checksum
 
 
 class TunedModel(BaseModel):
-    def __init__(self, df_train, df_test, feats_train, feats_test):
+    def __init__(self, df_train, df_test, feats_train, feats_test, context=None):
         """Constructor taking the configuration and all dataframes."""
-        super().__init__(df_train, df_test, feats_train, feats_test)
+        super().__init__(df_train, df_test, feats_train, feats_test, context=context)
         super().set_model_type("finetuned")
         self.df_test, self.df_train, self.feats_test, self.feats_train = (
             df_test,
@@ -38,8 +37,8 @@ class TunedModel(BaseModel):
             feats_train,
         )
         self.name = "finetuned_wav2vec2"
-        self.target = glob_conf.config["DATA"]["target"]
-        self.labels = glob_conf.labels
+        self.target = self.context.config["DATA"]["target"]
+        self.labels = self.context.labels
         self.class_num = len(self.labels)
         device = self.util.config_val("MODEL", "device", False)
         if not device:
@@ -98,7 +97,7 @@ class TunedModel(BaseModel):
         """Initialize HuggingFace transformer model for finetuning."""
         # create dataset
         dataset = {}
-        target_name = glob_conf.target
+        target_name = self.context.target
         data_sources = {
             "train": pd.DataFrame(self.df_train[target_name]),
             "dev": pd.DataFrame(self.df_test[target_name]),
@@ -123,7 +122,7 @@ class TunedModel(BaseModel):
         # load pre-trained model
         if self.is_classifier:
             self.util.debug("Task is classification.")
-            le = glob_conf.label_encoder
+            le = self.context.label_encoder
             if le is None:
                 self.util.error(
                     "Label encoder is not available. Make sure to set up data loading properly."
@@ -219,7 +218,7 @@ class TunedModel(BaseModel):
         )
 
         if self.is_classifier:
-            le = glob_conf.label_encoder
+            le = self.context.label_encoder
             if le is None:
                 self.util.error("Label encoder not available for classification")
                 return
@@ -252,7 +251,7 @@ class TunedModel(BaseModel):
     def _create_emotion2vec_dataset(self):
         """Create dataset for emotion2vec training."""
         dataset = {}
-        target_name = glob_conf.target
+        target_name = self.context.target
         data_sources = {
             "train": pd.DataFrame(self.df_train[target_name]),
             "dev": pd.DataFrame(self.df_test[target_name]),
@@ -601,6 +600,7 @@ class TunedModel(BaseModel):
             self.run,
             self.epoch_num,
             probas=probas,
+            context=self.context,
         )
         self._plot_epoch_progression(report)
         return report

--- a/nkululeko/nkululeko.py
+++ b/nkululeko/nkululeko.py
@@ -12,7 +12,6 @@ from pathlib import Path
 import numpy as np
 
 import nkululeko.experiment as exp
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
@@ -32,7 +31,7 @@ def doit(config_file):
     expr = exp.Experiment(config)
     module = "nkululeko"
     expr.set_module(module)
-    util = Util(module)
+    util = Util(module, context=expr.context)
     util.debug(
         f"running {expr.name} from config {config_file}, nkululeko version {VERSION}"
     )
@@ -52,9 +51,8 @@ def doit(config_file):
             " — loading best model, skipping training"
         )
         expr.load(save_name)
-        # Restore the label encoder in the global namespace so the Reporter
-        # can map integer class indices back to string label names.
-        glob_conf.set_label_encoder(expr.label_encoder)
+        # Restore the label encoder for reports generated from the saved model.
+        expr.context.label_encoder = expr.label_encoder
 
         # Load test data with original string labels (no encoding).
         expr.fill_tests(encode=False)

--- a/nkululeko/optim.py
+++ b/nkululeko/optim.py
@@ -7,7 +7,7 @@ import time
 from pathlib import Path
 
 from nkululeko.constants import VERSION
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ExperimentContext, set_context
 from nkululeko.optimizationrunner import OptimizationRunner
 from nkululeko.utils.errors import NkululukoError
 
@@ -21,9 +21,10 @@ def doit(config_file):
 
     config = configparser.ConfigParser()
     config.read(config_path)
-    glob_conf.init_config(config)
+    context = ExperimentContext(config=config)
+    set_context(context)
 
-    optimizer = OptimizationRunner(config)
+    optimizer = OptimizationRunner(config, context=context)
 
     start_time = time.time()
 

--- a/nkululeko/optimizationrunner.py
+++ b/nkululeko/optimizationrunner.py
@@ -14,9 +14,10 @@ from nkululeko.utils.util import Util
 class OptimizationRunner:
     """Hyperparameter optimization runner for nkululeko experiments."""
 
-    def __init__(self, config):
+    def __init__(self, config, context=None):
         self.config = config
-        self.util = Util("optim")
+        self.util = Util("optim", context=context)
+        self.context = self.util.context
         self.results = []
         self.model_type = None  # Will be set when parsing OPTIM params
         # New: Optimization strategy configuration

--- a/nkululeko/plots.py
+++ b/nkululeko/plots.py
@@ -12,7 +12,7 @@ from sklearn.manifold import TSNE
 import audeer
 from audmetric import concordance_cc as ccc
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.reporting.defines import Header
 from nkululeko.reporting.report_item import ReportItem
 import nkululeko.utils.stats as su
@@ -22,10 +22,11 @@ from nkululeko.utils.util import Util
 PLOT_BASENAME_MAX_LEN = 240
 
 
-class Plots:
-    def __init__(self):
+class Plots(ContextAware):
+    def __init__(self, context=None):
         """Initializing the util system."""
-        self.util = Util("plots")
+        self.util = Util("plots", context=context)
+        self.context = self.util.context
         self.format = self.util.config_val("PLOT", "format", "png")
         self.target = self.util.config_val("DATA", "target", "emotion")
         self.with_ccc = eval(self.util.config_val("PLOT", "ccc", "False"))
@@ -296,7 +297,7 @@ class Plots:
         plt.savefig(img_path)
         plt.close(fig_plots)
         self.util.debug(f"Saved plot to {img_path}")
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 header,
@@ -530,7 +531,7 @@ class Plots:
         plt.savefig(img_path)
         plt.close(fig)
         self.util.debug(f"plotted durations to {img_path}")
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 caption,
@@ -561,7 +562,7 @@ class Plots:
         plt.savefig(img_path)
         plt.close(fig)
         self.util.debug(f"plotted speakers to {img_path}")
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 caption,
@@ -608,7 +609,7 @@ class Plots:
             plt.savefig(img_path)
             fig.clear()
             plt.close(fig)
-            glob_conf.report.add_item(
+            self.context.report.add_item(
                 ReportItem(
                     Header.HEADER_EXPLORE,
                     f"Overview on {df.shape[0]} samples",
@@ -745,7 +746,7 @@ class Plots:
         self.util.debug(f"plotted {dimred_type} scatter plot to {filename}")
         fig.clear()
         plt.close(fig)
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 "Scatter plot",
@@ -923,7 +924,7 @@ class Plots:
         plt.close(fig)
         caption = f"Feature plot for feature {feature}"
         content = caption
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 caption,
@@ -1065,7 +1066,7 @@ class Plots:
         fig.savefig(filename)
         fig.clear()
         plt.close(fig)
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_EXPLORE,
                 "Tree plot",

--- a/nkululeko/predict.py
+++ b/nkululeko/predict.py
@@ -45,8 +45,8 @@ import numpy as np
 import pandas as pd
 from tqdm import tqdm
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.constants import VERSION, SAMPLING_RATE
+from nkululeko.experiment_context import ExperimentContext, set_context
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.files import find_files
 from nkululeko.utils.util import Util
@@ -177,9 +177,9 @@ def main():
         config = _load_config(args)
         if args.language:
             _apply_language_override(config, args.language)
-        glob_conf.init_config(config)
-        glob_conf.set_module(module_name)
-        util = Util(module_name, has_config=True)
+        context = ExperimentContext(config=config, module=module_name)
+        set_context(context)
+        util = Util(module_name, has_config=True, context=context)
         util.debug(f"nkululeko {VERSION}: {module_name}")
         if args.language:
             util.debug(
@@ -241,7 +241,7 @@ def do_test(config_file, outfile):
 
     expr = Experiment(config)
     expr.set_module("test")
-    util = Util("test", has_config=True)
+    util = Util("test", has_config=True, context=expr.context)
     util.debug(f"running {expr.name} from config {config_file}, nkululeko {VERSION}")
 
     expr.load(f"{util.get_save_name()}")
@@ -534,7 +534,7 @@ def _run_from_config(args, util):
     """
     from nkululeko.experiment import Experiment
 
-    expr = Experiment(glob_conf.config)
+    expr = Experiment(util.context.config)
     expr.set_module("predict")
     util.debug(f"loading dataframe from config {args.config!r}")
     expr.load_datasets()
@@ -591,8 +591,8 @@ def _predict_with_autopredict(seg_df, target, util):
     """Use an nkululeko.autopredict.* predictor for one of the known targets."""
     util.debug(f"autopredict target: {target}")
     # ensure DATA.databases is parseable by the predictors
-    if "databases" not in glob_conf.config["DATA"]:
-        glob_conf.config["DATA"]["databases"] = "['adhoc']"
+    if "databases" not in util.context.config["DATA"]:
+        util.context.config["DATA"]["databases"] = "['adhoc']"
 
     df_in = seg_df.copy()
     pred_df = _dispatch_autopredict(target, df_in)
@@ -731,7 +731,7 @@ def _predict_with_model(seg_df, args, util):
     """Load the experiment from --config and run its best model on each file."""
     from nkululeko.experiment import Experiment
 
-    config = glob_conf.config
+    config = util.context.config
     expr = Experiment(config)
     expr.set_module("predict")
     expr.load(f"{util.get_save_name()}")

--- a/nkululeko/reporting/reporter.py
+++ b/nkululeko/reporting/reporter.py
@@ -23,7 +23,7 @@ from audmetric import mean_absolute_error
 from audmetric import mean_squared_error
 from audmetric import unweighted_average_recall
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware
 from nkululeko.plots import Plots
 
 
@@ -74,7 +74,7 @@ def equal_error_rate(y_true, y_score):
     return float(eer)
 
 
-class Reporter:
+class Reporter(ContextAware):
     def _set_metric(self):
         if self.util.exp_is_classification():
             # Check if user wants EER metric instead of default UAR
@@ -100,7 +100,7 @@ class Reporter:
                 self.METRIC = "CCC"
                 self.result.metric = self.METRIC
 
-    def __init__(self, truths, preds, run, epoch, probas=None):
+    def __init__(self, truths, preds, run, epoch, probas=None, context=None):
         """Initialization with ground truth und predictions vector.
 
         Args:
@@ -110,7 +110,8 @@ class Reporter:
             epoch (int): number of epoch
             probas (pd.Dataframe, optional): probabilities per class. Defaults to None.
         """
-        self.util = Util("reporter")
+        self.util = Util("reporter", context=context)
+        self.context = self.util.context
         self.probas = probas
         self.format = self.util.config_val("PLOT", "format", "png")
         self.truths = np.asarray(truths)
@@ -226,7 +227,7 @@ class Reporter:
             probas["predicted"] = self.preds
             probas["truth"] = self.truths
             try:
-                le = glob_conf.label_encoder
+                le = self.context.label_encoder
                 if le is not None:
                     mapping = dict(zip(le.classes_, range(len(le.classes_))))
                     mapping_reverse = {value: key for key, value in mapping.items()}
@@ -240,7 +241,7 @@ class Reporter:
             # compute entropy per sample
             uncertainty = uncertainty.apply(entropy)
             # scale it to 0-1
-            max_ent = math.log(len(glob_conf.labels))
+            max_ent = math.log(len(self.context.labels))
             uncertainty = (uncertainty - uncertainty.min()) / (
                 max_ent - uncertainty.min()
             )
@@ -265,7 +266,7 @@ class Reporter:
             self.plot_proba_conf()
             probas.to_csv(file_name)
             self.util.debug(f"Saved probabilities to {file_name}")
-            plots = Plots()
+            plots = Plots(context=self.context)
             ax, caption = plots.plotcatcont(
                 probas, "correct", "uncertainty", "uncertainty", "correct"
             )
@@ -319,9 +320,11 @@ class Reporter:
             self.util.debug(f"Set default labels for binning: {labels}")
         # if there are no bins, set them to border points for the labels and save them to the config to be used later
         try:
-            bins = ast.literal_eval(glob_conf.config["DATA"]["bins"])
+            bins = ast.literal_eval(self.context.config["DATA"]["bins"])
         except (KeyError, ValueError):
-            label_num = len(ast.literal_eval(glob_conf.config["DATA"]["labels"]))
+            label_num = len(
+                ast.literal_eval(self.context.config["DATA"]["labels"])
+            )
             vmin, vmax = np.percentile(self.truths, [5, 95])
             inner_edges = np.linspace(vmin, vmax, label_num + 1)[1:-1]
             bins = [-np.inf] + inner_edges.tolist() + [np.inf]
@@ -428,7 +431,7 @@ class Reporter:
         plt.close(fig)
         plt.close()
         plt.clf()
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_RESULTS,
                 self.util.get_model_description(),
@@ -452,12 +455,12 @@ class Reporter:
             alpha=5,
         )
         acc = accuracy(truths, preds)
-        le = glob_conf.label_encoder
+        le = self.context.label_encoder
 
         # if labels come from binning, try to get the original labels for the confusion matrix
         if not self.util.exp_is_classification():
             try:
-                labels = ast.literal_eval(glob_conf.config["DATA"]["labels"])
+                labels = ast.literal_eval(self.context.config["DATA"]["labels"])
             except KeyError:
                 # No label names configured — derive bin indices from the data
                 n_bins = max(int(max(list(truths) + list(preds))) + 1, 1)
@@ -508,7 +511,7 @@ class Reporter:
         plt.close(fig)
         plt.close()
         plt.clf()
-        glob_conf.report.add_item(
+        self.context.report.add_item(
             ReportItem(
                 Header.HEADER_RESULTS,
                 self.util.get_model_description(),
@@ -568,10 +571,10 @@ class Reporter:
             self.util.debug(f"####->{file_name}<-####")
             file_name = _safe_path(res_dir, f"{file_name}{self.filenameadd}", "txt")
         if self.util.exp_is_classification():
-            if glob_conf.label_encoder is not None:
-                labels = glob_conf.label_encoder.classes_
+            if self.context.label_encoder is not None:
+                labels = self.context.label_encoder.classes_
             else:
-                labels = glob_conf.labels
+                labels = self.context.labels
             try:
                 rpt = classification_report(
                     self.truths,
@@ -616,7 +619,7 @@ class Reporter:
                     if uar_val is not None:
                         rpt_str += f", UAR: {float(uar_val):.4f}"
                 text_file.write(rpt_str)
-                glob_conf.report.add_item(
+                self.context.report.add_item(
                     ReportItem(
                         Header.HEADER_RESULTS,
                         f"Classification result {self.util.get_model_description()}",

--- a/nkululeko/reporting/reporter.py
+++ b/nkululeko/reporting/reporter.py
@@ -595,9 +595,11 @@ class Reporter(ContextAware):
             except ValueError as e:
                 self.util.debug(
                     "Reporter: caught a ValueError when trying to get"
-                    " classification_report: " + e
+                    f" classification_report: {e}"
                 )
-                rpt = self.result.to_string()
+                with open(file_name, "w") as text_file:
+                    text_file.write(self.result.to_string())
+                return
             with open(file_name, "w") as text_file:
                 c_ress = list(range(len(labels)))
                 for i, label in enumerate(labels):
@@ -649,7 +651,7 @@ class Reporter(ContextAware):
         try:
             imageio.mimsave(fig_dir + out_name, images, fps=int(fps))
         except RuntimeError as e:
-            self.util.error("error writing anim gif: " + e)
+            self.util.error(f"error writing anim gif: {e}")
 
     def get_result(self):
         return self.result

--- a/nkululeko/runmanager.py
+++ b/nkululeko/runmanager.py
@@ -4,13 +4,13 @@ This module contains the Runmanager class which is responsible for managing the
 runs of the experiment.
 """
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ContextAware, use_context
 from nkululeko.modelrunner import Modelrunner
 from nkululeko.reporting.reporter import Reporter
 from nkululeko.utils.util import Util
 
 
-class Runmanager:
+class Runmanager(ContextAware):
     """Class to manage the runs of the experiment (e.g. when results differ caused by random initialization)."""
 
     model = None  # The underlying model
@@ -23,7 +23,14 @@ class Runmanager:
     reports = []
 
     def __init__(
-        self, df_train, df_test, feats_train, feats_test, dev_x=None, dev_y=None
+        self,
+        df_train,
+        df_test,
+        feats_train,
+        feats_test,
+        dev_x=None,
+        dev_y=None,
+        context=None,
     ):
         """Constructor setting up the dataframes.
 
@@ -41,8 +48,9 @@ class Runmanager:
             feats_test,
         )
         self.df_dev, self.feats_dev = dev_x, dev_y
-        self.util = Util("runmanager")
-        self.target = glob_conf.config["DATA"]["target"]
+        self.util = Util("runmanager", context=context)
+        self.context = self.util.context
+        self.target = self.context.config["DATA"]["target"]
         self.split3 = eval(self.util.config_val("EXP", "traindevtest", "False"))
 
     def do_runs(self):
@@ -52,29 +60,33 @@ class Runmanager:
         # for all runs
         for run in range(int(self.util.config_val("EXP", "runs", 1))):
             self.util.debug(
-                f"run {run} using model {glob_conf.config['MODEL']['type']}"
+                f"run {run} using model {self.context.config['MODEL']['type']}"
             )
             # set the run index as global variable for reporting
             self.util.set_config_val("EXP", "run", run)
             if self.df_dev is not None:
-                self.modelrunner = Modelrunner(
-                    self.df_train,
-                    self.df_dev,
-                    self.feats_train,
-                    self.feats_dev,
-                    run,
-                    split_name="dev",
-                )
+                with use_context(self.context):
+                    self.modelrunner = Modelrunner(
+                        self.df_train,
+                        self.df_dev,
+                        self.feats_train,
+                        self.feats_dev,
+                        run,
+                        split_name="dev",
+                        context=self.context,
+                    )
                 self.reports, last_epoch = self.modelrunner.do_epochs()
             else:
-                self.modelrunner = Modelrunner(
-                    self.df_train,
-                    self.df_test,
-                    self.feats_train,
-                    self.feats_test,
-                    run,
-                    split_name="test",
-                )
+                with use_context(self.context):
+                    self.modelrunner = Modelrunner(
+                        self.df_train,
+                        self.df_test,
+                        self.feats_train,
+                        self.feats_test,
+                        run,
+                        split_name="test",
+                        context=self.context,
+                    )
                 self.reports, last_epoch = self.modelrunner.do_epochs()
 
             last_report = self.reports[-1]
@@ -100,7 +112,7 @@ class Runmanager:
                 "PLOT", "epoch_progression", 0
             )
             try:
-                epoch_num = int(glob_conf.config["EXP"]["epochs"])
+                epoch_num = int(self.context.config["EXP"]["epochs"])
             except KeyError:
                 # possibly this value has not been set
                 epoch_num = 1
@@ -171,8 +183,7 @@ class Runmanager:
             epoch: for which epoch
 
         """
-        report = Reporter([], [])
-        report.set_id(run, epoch)
+        report = Reporter([], [], run, epoch, context=self.context)
         self.util.debug(f"Re-testing result with run {run} and epoch {epoch}")
         plot_name_suggest = self.util.get_exp_name()
         plot_name = (
@@ -205,7 +216,7 @@ class Runmanager:
         run = report.run
         epoch = report.epoch
         self.util.set_config_val("EXP", "run", run)
-        model_type = glob_conf.config["MODEL"]["type"]
+        model_type = self.context.config["MODEL"]["type"]
         model = self.modelrunner._select_model(model_type)
         model.load(run, epoch)
         return model
@@ -215,7 +226,7 @@ class Runmanager:
         return self.load_model(best_report)
 
     def get_best_result(self, reports):
-        best_r = Reporter([], [], None, 0, 0)
+        best_r = Reporter([], [], None, 0, 0, context=self.context)
         if self.util.high_is_good():
             best_r = self.search_best_result(reports, "ascending")
         else:
@@ -223,7 +234,7 @@ class Runmanager:
         return best_r
 
     def search_best_result(self, reports, order):
-        best_r = Reporter([], [], None, 0, 0)
+        best_r = Reporter([], [], None, 0, 0, context=self.context)
         if order == "ascending":
             best_result = 0
             for r in reports:

--- a/nkululeko/scaler.py
+++ b/nkululeko/scaler.py
@@ -27,6 +27,7 @@ class Scaler:
         scaler_type,
         dev_x=None,
         dev_y=None,
+        context=None,
     ):
         """Constructor.
 
@@ -38,7 +39,7 @@ class Scaler:
                 train_feats (pd.DataFrame): The train features dataframe
                 test_feats (pd.DataFrame): The test features dataframe (can be None)
         """
-        self.util = Util("scaler")
+        self.util = Util("scaler", context=context)
         if scaler_type == "standard":
             self.scaler = StandardScaler()
         elif scaler_type == "robust":

--- a/nkululeko/segment.py
+++ b/nkululeko/segment.py
@@ -33,7 +33,7 @@ import pandas as pd
 
 from nkululeko.constants import VERSION
 from nkululeko.experiment import Experiment
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ExperimentContext, set_context
 from nkululeko.reporting.report_item import ReportItem
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.util import Util
@@ -133,9 +133,10 @@ def _run_file_mode(args):
     # read max_length / min_length via util.config_val without a full INI.
     config = configparser.ConfigParser()
     _apply_cli_overrides(args, config)
-    glob_conf.init_config(config)
+    context = ExperimentContext(config=config)
+    set_context(context)
 
-    util = Util("segment", has_config=True)
+    util = Util("segment", has_config=True, context=context)
     util.debug(f"segmenting file: {args.file}")
 
     files = pd.Series([args.file])
@@ -214,7 +215,7 @@ def main():
         expr = Experiment(config)
         module = "segment"
         expr.set_module(module)
-        util = Util(module)
+        util = Util(module, context=expr.context)
         util.debug(f"running {expr.name}, nkululeko version {VERSION}")
 
         if util.config_val("EXP", "no_warnings", False):
@@ -289,7 +290,7 @@ def main():
                 df["duration"] = df.index.to_series().map(lambda x: calc_dur(x))
             df_seg["duration"] = df_seg.index.to_series().map(lambda x: calc_dur(x))
             df_silence["duration"] = df_silence.index.to_series().map(lambda x: calc_dur(x))
-            plots = Plots()
+            plots = Plots(context=expr.context)
             plots.plot_durations(
                 df, "original_durations", sample_selection, caption="Original durations"
             )
@@ -334,7 +335,7 @@ def main():
             f" {num_before})"
         )
 
-        glob_conf.report.add_item(
+        expr.context.report.add_item(
             ReportItem(
                 "Data",
                 "Segmentation",

--- a/nkululeko/testing_predictor.py
+++ b/nkululeko/testing_predictor.py
@@ -10,7 +10,6 @@ import os
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
-import nkululeko.glob_conf as glob_conf
 from nkululeko.data.dataset import Dataset
 from nkululeko.feature_extractor import FeatureExtractor
 from nkululeko.scaler import Scaler
@@ -18,32 +17,37 @@ from nkululeko.utils.util import Util
 
 
 class TestPredictor:
-    def __init__(self, model, orig_df, labenc, name):
+    def __init__(self, model, orig_df, labenc, name, context=None):
         """Constructor setting up name and configuration."""
         self.model = model
         self.orig_df = orig_df
         self.label_encoder = labenc
-        self.target = glob_conf.config["DATA"]["target"]
-        self.util = Util("testing_predictor")
+        self.util = Util("testing_predictor", context=context)
+        self.context = self.util.context
+        self.target = self.context.config["DATA"]["target"]
         self.name = name
 
     def predict_and_store(self):
         label_data = self.util.config_val("DATA", "label_data", False)
         result = 0
         if label_data:
-            data = Dataset(label_data)
+            data = Dataset(label_data, context=self.context)
             data.load()
             data.prepare_labels()
             data_df = self.util.make_segmented_index(data.df)
             data_df.is_labeled = data.is_labeled
 
-            featextractor = FeatureExtractor(data_df, label_data, "")
+            featextractor = FeatureExtractor(
+                data_df, label_data, "", context=self.context
+            )
             feats_df = featextractor.extract()
             scale = self.util.config_val("FEATS", "scale", False)
             labelenc = LabelEncoder()
             data_df[self.target] = labelenc.fit_transform(data_df[self.target])
             if scale:
-                self.scaler = Scaler(data_df, None, feats_df, None, scale)
+                self.scaler = Scaler(
+                    data_df, None, feats_df, None, scale, context=self.context
+                )
                 feats_df, _ = self.scaler.scale()
             self.model.set_testdata(data_df, feats_df)
             predictions = self.model.get_predictions()
@@ -53,7 +57,7 @@ class TestPredictor:
             df[self.target] = labelenc.inverse_transform(predictions.tolist())
             df.to_csv(self.name)
         elif self.util.config_val("DATA", "tests", False):
-            test_dbs = ast.literal_eval(glob_conf.config["DATA"]["tests"])
+            test_dbs = ast.literal_eval(self.context.config["DATA"]["tests"])
             test_dbs_string = "_".join(test_dbs)
             predictions, _ = self.model.get_predictions()
             report = self.model.predict()

--- a/nkululeko/testing_pretrain.py
+++ b/nkululeko/testing_pretrain.py
@@ -14,7 +14,6 @@ import torch
 import transformers
 
 import nkululeko.experiment as exp
-import nkululeko.glob_conf as glob_conf
 import nkululeko.models.model_tuned as mt
 from nkululeko.constants import VERSION
 from nkululeko.utils.util import Util
@@ -34,7 +33,7 @@ def doit(config_file):
     expr = exp.Experiment(config)
     module = "testing_pretrain"
     expr.set_module(module)
-    util = Util(module)
+    util = Util(module, context=expr.context)
     util.debug(
         f"running {expr.name} from config {config_file}, nkululeko version"
         f" {VERSION}"
@@ -75,7 +74,7 @@ def doit(config_file):
     # create dataset
 
     dataset = {}
-    target_name = glob_conf.target
+    target_name = expr.context.target
     data_sources = {
         "train": pd.DataFrame(expr.df_train[target_name]),
         "dev": pd.DataFrame(expr.df_test[target_name]),
@@ -105,7 +104,7 @@ def doit(config_file):
     dataset = datasets.DatasetDict(dataset)
 
     # load pre-trained model
-    le = glob_conf.label_encoder
+    le = expr.context.label_encoder
     mapping = dict(zip(le.classes_, range(len(le.classes_))))
     target_mapping = {k: int(v) for k, v in mapping.items()}
     target_mapping_reverse = {value: key for key, value in target_mapping.items()}

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -16,6 +16,7 @@ from nkululeko.utils.dataframe import DataFrameMixin
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.naming import NamingMixin
 from nkululeko.utils.storage import StorageMixin
+from nkululeko.experiment_context import get_context
 
 
 class _MessageOnlyFormatter(logging.Formatter):
@@ -47,8 +48,14 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         "kind",
     ]
 
-    def __init__(self, caller=None, has_config=True):
+    def __init__(self, caller=None, has_config=True, context=None):
+        """Create a utility helper bound to an experiment context.
+
+        ``context`` is optional only for backwards compatibility with callers
+        outside the experiment orchestration layer.
+        """
         self.logger = None
+        self.context = context if context is not None else get_context()
         if caller is not None:
             self.caller = caller
         else:
@@ -56,9 +63,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         self.config = None
         if has_config:
             try:
-                import nkululeko.glob_conf as glob_conf
-
-                self.config = glob_conf.config
+                self.config = self.context.config
                 self.got_data_roots = self.config_val("DATA", "root_folders", False)
                 if self.got_data_roots:
                     # if there is a global data rootfolder file, read from
@@ -67,10 +72,6 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
                         self.error(f"no such file: {self.got_data_roots}")
                     self.data_roots = configparser.ConfigParser()
                     self.data_roots.read(self.got_data_roots)
-            except ModuleNotFoundError as e:
-                self.error(e)
-                self.config = None
-                self.got_data_roots = False
             except AttributeError as e:
                 self.error(e)
                 self.config = None
@@ -209,9 +210,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         If the value is present in the experiment configuration it will be used, else
         we look in a global file specified by the root_folders value.
         """
-        import nkululeko.glob_conf as glob_conf
-
-        configuration = glob_conf.config
+        configuration = self.config
         try:
             if len(key) > 0:
                 return configuration["DATA"][dataset + "." + key].strip("'\"")
@@ -236,6 +235,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
 
     def set_config(self, config):
         self.config = config
+        self.context.config = config
         # self.logged_configs.clear()
 
     def get_name(self):

--- a/nkululeko/utils/util.py
+++ b/nkululeko/utils/util.py
@@ -17,6 +17,7 @@ from nkululeko.utils.dataframe import DataFrameMixin
 from nkululeko.utils.errors import NkululukoError
 from nkululeko.utils.naming import NamingMixin
 from nkululeko.utils.storage import StorageMixin
+from nkululeko.experiment_context import get_context
 
 _log_lock = threading.Lock()
 
@@ -50,8 +51,14 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         "kind",
     ]
 
-    def __init__(self, caller=None, has_config=True):
+    def __init__(self, caller=None, has_config=True, context=None):
+        """Create a utility helper bound to an experiment context.
+
+        ``context`` is optional only for backwards compatibility with callers
+        outside the experiment orchestration layer.
+        """
         self.logger = None
+        self.context = context if context is not None else get_context()
         if caller is not None:
             self.caller = caller
         else:
@@ -59,9 +66,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         self.config = None
         if has_config:
             try:
-                import nkululeko.glob_conf as glob_conf
-
-                self.config = glob_conf.config
+                self.config = self.context.config
                 self.got_data_roots = self.config_val("DATA", "root_folders", False)
                 if self.got_data_roots:
                     # if there is a global data rootfolder file, read from
@@ -70,10 +75,6 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
                         self.error(f"no such file: {self.got_data_roots}")
                     self.data_roots = configparser.ConfigParser()
                     self.data_roots.read(self.got_data_roots)
-            except ModuleNotFoundError as e:
-                self.error(e)
-                self.config = None
-                self.got_data_roots = False
             except AttributeError as e:
                 self.error(e)
                 self.config = None
@@ -220,9 +221,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
         If the value is present in the experiment configuration it will be used, else
         we look in a global file specified by the root_folders value.
         """
-        import nkululeko.glob_conf as glob_conf
-
-        configuration = glob_conf.config
+        configuration = self.config
         try:
             if len(key) > 0:
                 return configuration["DATA"][dataset + "." + key].strip("'\"")
@@ -247,6 +246,7 @@ class Util(NamingMixin, StorageMixin, DataFrameMixin):
 
     def set_config(self, config):
         self.config = config
+        self.context.config = config
         # self.logged_configs.clear()
 
     def get_name(self):

--- a/tests/autopredict/test_ap_age.py
+++ b/tests/autopredict/test_ap_age.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock, patch
 import pandas as pd
 
 from nkululeko.autopredict.ap_age import AgePredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestAgePredictor:
-    @patch("nkululeko.autopredict.ap_age.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = AgePredictor(df)
 
@@ -15,9 +15,8 @@ class TestAgePredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_age.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_age.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with age values
         mock_age_df = pd.DataFrame({"age": [0.25, 0.45, 0.70]})
@@ -26,9 +25,9 @@ class TestAgePredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = AgePredictor(df)
-
-        result = predictor.predict("train")
+        with use_context(context):
+            predictor = AgePredictor(df)
+            result = predictor.predict("train")
 
         assert "age_pred" in result.columns
         assert len(result) == 3

--- a/tests/autopredict/test_ap_arousal.py
+++ b/tests/autopredict/test_ap_arousal.py
@@ -4,11 +4,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_arousal import ArousalPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestArousalPredictor:
-    @patch("nkululeko.autopredict.ap_arousal.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = ArousalPredictor(df)
 
@@ -16,9 +16,8 @@ class TestArousalPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_arousal.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_arousal.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with arousal values
         mock_arousal_df = pd.DataFrame({"arousal": [0.25, 0.45, 0.70]})
@@ -27,9 +26,10 @@ class TestArousalPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = ArousalPredictor(df)
+        with use_context(context):
+            predictor = ArousalPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "arousal_pred" in result.columns
         assert len(result) == 3

--- a/tests/autopredict/test_ap_dominance.py
+++ b/tests/autopredict/test_ap_dominance.py
@@ -4,11 +4,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_dominance import DominancePredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestDominancePredictor:
-    @patch("nkululeko.autopredict.ap_dominance.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = DominancePredictor(df)
 
@@ -16,9 +16,8 @@ class TestDominancePredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_dominance.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_dominance.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with dominance values
         mock_dominance_df = pd.DataFrame({"dominance": [0.25, 0.45, 0.70]})
@@ -27,9 +26,10 @@ class TestDominancePredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = DominancePredictor(df)
+        with use_context(context):
+            predictor = DominancePredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "dominance_pred" in result.columns
         assert len(result) == 3

--- a/tests/autopredict/test_ap_emotion.py
+++ b/tests/autopredict/test_ap_emotion.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock, patch
 import pandas as pd
 
 from nkululeko.autopredict.ap_emotion import EmotionPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestEmotionPredictor:
-    @patch("nkululeko.autopredict.ap_emotion.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = EmotionPredictor(df)
 
@@ -15,9 +15,8 @@ class TestEmotionPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_emotion.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_emotion.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe
         mock_emotion_df = pd.DataFrame({"feat1": [0.1, 0.2, 0.3]})
@@ -26,9 +25,10 @@ class TestEmotionPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = EmotionPredictor(df)
+        with use_context(context):
+            predictor = EmotionPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "emotion_pred" in result.columns
         assert len(result) == 3

--- a/tests/autopredict/test_ap_gender.py
+++ b/tests/autopredict/test_ap_gender.py
@@ -3,11 +3,11 @@ from unittest.mock import Mock, patch
 import pandas as pd
 
 from nkululeko.autopredict.ap_gender import GenderPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestGenderPredictor:
-    @patch("nkululeko.autopredict.ap_gender.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = GenderPredictor(df)
 
@@ -15,9 +15,8 @@ class TestGenderPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_gender.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_gender.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with age and gender columns
         mock_agender_df = pd.DataFrame(
@@ -32,9 +31,10 @@ class TestGenderPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = GenderPredictor(df)
+        with use_context(context):
+            predictor = GenderPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "gender_pred" in result.columns
         assert len(result) == 3

--- a/tests/autopredict/test_ap_mos.py
+++ b/tests/autopredict/test_ap_mos.py
@@ -5,11 +5,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_mos import MOSPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestMOSPredictor:
-    @patch("nkululeko.autopredict.ap_mos.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = MOSPredictor(df)
 
@@ -17,9 +17,8 @@ class TestMOSPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_mos.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_mos.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with MOS values
         mock_mos_df = pd.DataFrame({"mos": [3.5, 4.2, 2.8]})
@@ -28,9 +27,10 @@ class TestMOSPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = MOSPredictor(df)
+        with use_context(context):
+            predictor = MOSPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "mos_pred" in result.columns
         assert len(result) == 3
@@ -39,9 +39,8 @@ class TestMOSPredictor:
         assert result["mos_pred"].iloc[1] == pytest.approx(4.2, abs=0.01)
 
     @patch("nkululeko.autopredict.ap_mos.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_mos.glob_conf")
-    def test_predict_handles_nan_and_inf(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict_handles_nan_and_inf(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with NaN and inf values
         mock_mos_df = pd.DataFrame({"mos": [3.5, np.nan, np.inf, -np.inf]})
@@ -50,9 +49,10 @@ class TestMOSPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3, 4]})
-        predictor = MOSPredictor(df)
+        with use_context(context):
+            predictor = MOSPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "mos_pred" in result.columns
         # NaN and inf values should be replaced with 0

--- a/tests/autopredict/test_ap_pesq.py
+++ b/tests/autopredict/test_ap_pesq.py
@@ -5,11 +5,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_pesq import PESQPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestPESQPredictor:
-    @patch("nkululeko.autopredict.ap_pesq.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = PESQPredictor(df)
 
@@ -17,9 +17,8 @@ class TestPESQPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_pesq.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_pesq.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with PESQ values
         mock_pesq_df = pd.DataFrame({"pesq": [3.5, 4.2, 2.8]})
@@ -28,18 +27,18 @@ class TestPESQPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = PESQPredictor(df)
+        with use_context(context):
+            predictor = PESQPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "pesq_pred" in result.columns
         assert len(result) == 3
         assert result["pesq_pred"].iloc[0] == pytest.approx(3.5, abs=0.01)
 
     @patch("nkululeko.autopredict.ap_pesq.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_pesq.glob_conf")
-    def test_predict_handles_nan_and_inf(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict_handles_nan_and_inf(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         mock_pesq_df = pd.DataFrame({"pesq": [3.5, np.nan, np.inf, -np.inf]})
         mock_extractor = Mock()
@@ -47,9 +46,10 @@ class TestPESQPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3, 4]})
-        predictor = PESQPredictor(df)
+        with use_context(context):
+            predictor = PESQPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert result["pesq_pred"].iloc[1] == pytest.approx(0.0)
         assert result["pesq_pred"].iloc[2] == pytest.approx(0.0)

--- a/tests/autopredict/test_ap_sdr.py
+++ b/tests/autopredict/test_ap_sdr.py
@@ -5,11 +5,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_sdr import SDRPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestSDRPredictor:
-    @patch("nkululeko.autopredict.ap_sdr.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = SDRPredictor(df)
 
@@ -17,9 +17,8 @@ class TestSDRPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_sdr.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_sdr.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with SDR values
         mock_sdr_df = pd.DataFrame({"sdr": [12.5, 15.2, 9.8]})
@@ -28,18 +27,18 @@ class TestSDRPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = SDRPredictor(df)
+        with use_context(context):
+            predictor = SDRPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "sdr_pred" in result.columns
         assert len(result) == 3
         assert result["sdr_pred"].iloc[0] == pytest.approx(12.5, abs=0.01)
 
     @patch("nkululeko.autopredict.ap_sdr.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_sdr.glob_conf")
-    def test_predict_handles_nan_and_inf(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict_handles_nan_and_inf(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         mock_sdr_df = pd.DataFrame({"sdr": [12.5, np.nan, np.inf, -np.inf]})
         mock_extractor = Mock()
@@ -47,9 +46,10 @@ class TestSDRPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3, 4]})
-        predictor = SDRPredictor(df)
+        with use_context(context):
+            predictor = SDRPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert result["sdr_pred"].iloc[1] == pytest.approx(0.0)
         assert result["sdr_pred"].iloc[2] == pytest.approx(0.0)

--- a/tests/autopredict/test_ap_snr.py
+++ b/tests/autopredict/test_ap_snr.py
@@ -5,11 +5,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_snr import SNRPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestSNRPredictor:
-    @patch("nkululeko.autopredict.ap_snr.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = SNRPredictor(df)
 
@@ -17,9 +17,8 @@ class TestSNRPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_snr.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_snr.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with SNR values
         mock_snr_df = pd.DataFrame({"snr": [15.5, 20.2, 10.8]})
@@ -28,18 +27,18 @@ class TestSNRPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = SNRPredictor(df)
+        with use_context(context):
+            predictor = SNRPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "snr_pred" in result.columns
         assert len(result) == 3
         assert result["snr_pred"].iloc[0] == pytest.approx(15.5, abs=0.01)
 
     @patch("nkululeko.autopredict.ap_snr.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_snr.glob_conf")
-    def test_predict_handles_nan_and_inf(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict_handles_nan_and_inf(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         mock_snr_df = pd.DataFrame({"snr": [15.5, np.nan, np.inf, -np.inf]})
         mock_extractor = Mock()
@@ -47,9 +46,10 @@ class TestSNRPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3, 4]})
-        predictor = SNRPredictor(df)
+        with use_context(context):
+            predictor = SNRPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert result["snr_pred"].iloc[1] == pytest.approx(0.0)
         assert result["snr_pred"].iloc[2] == pytest.approx(0.0)

--- a/tests/autopredict/test_ap_stoi.py
+++ b/tests/autopredict/test_ap_stoi.py
@@ -5,11 +5,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_stoi import STOIPredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestSTOIPredictor:
-    @patch("nkululeko.autopredict.ap_stoi.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = STOIPredictor(df)
 
@@ -17,9 +17,8 @@ class TestSTOIPredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_stoi.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_stoi.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with STOI values
         mock_stoi_df = pd.DataFrame({"stoi": [0.85, 0.92, 0.78]})
@@ -28,18 +27,18 @@ class TestSTOIPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = STOIPredictor(df)
+        with use_context(context):
+            predictor = STOIPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "stoi_pred" in result.columns
         assert len(result) == 3
         assert result["stoi_pred"].iloc[0] == pytest.approx(0.85, abs=0.01)
 
     @patch("nkululeko.autopredict.ap_stoi.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_stoi.glob_conf")
-    def test_predict_handles_nan_and_inf(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict_handles_nan_and_inf(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         mock_stoi_df = pd.DataFrame({"stoi": [0.85, np.nan, np.inf, -np.inf]})
         mock_extractor = Mock()
@@ -47,9 +46,10 @@ class TestSTOIPredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3, 4]})
-        predictor = STOIPredictor(df)
+        with use_context(context):
+            predictor = STOIPredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert result["stoi_pred"].iloc[1] == pytest.approx(0.0)
         assert result["stoi_pred"].iloc[2] == pytest.approx(0.0)

--- a/tests/autopredict/test_ap_valence.py
+++ b/tests/autopredict/test_ap_valence.py
@@ -4,11 +4,11 @@ import pandas as pd
 import pytest
 
 from nkululeko.autopredict.ap_valence import ValencePredictor
+from nkululeko.experiment_context import ExperimentContext, use_context
 
 
 class TestValencePredictor:
-    @patch("nkululeko.autopredict.ap_valence.glob_conf")
-    def test_init(self, mock_glob_conf):
+    def test_init(self):
         df = pd.DataFrame({"dummy": [1, 2, 3]})
         predictor = ValencePredictor(df)
 
@@ -16,9 +16,8 @@ class TestValencePredictor:
         assert predictor.util is not None
 
     @patch("nkululeko.autopredict.ap_valence.FeatureExtractor")
-    @patch("nkululeko.autopredict.ap_valence.glob_conf")
-    def test_predict(self, mock_glob_conf, mock_feature_extractor):
-        mock_glob_conf.config = {"DATA": {"databases": "['test_db']"}}
+    def test_predict(self, mock_feature_extractor):
+        context = ExperimentContext(config={"DATA": {"databases": "['test_db']"}})
 
         # Create mock dataframe with valence values
         mock_valence_df = pd.DataFrame({"valence": [0.25, 0.45, 0.70]})
@@ -27,9 +26,10 @@ class TestValencePredictor:
         mock_feature_extractor.return_value = mock_extractor
 
         df = pd.DataFrame({"dummy": [1, 2, 3]})
-        predictor = ValencePredictor(df)
+        with use_context(context):
+            predictor = ValencePredictor(df)
 
-        result = predictor.predict("train")
+            result = predictor.predict("train")
 
         assert "valence_pred" in result.columns
         assert len(result) == 3

--- a/tests/feat_extract/test_feats_bert.py
+++ b/tests/feat_extract/test_feats_bert.py
@@ -3,6 +3,7 @@ import pandas as pd
 import numpy as np
 import torch
 from unittest.mock import MagicMock, patch
+from nkululeko.experiment_context import ExperimentContext
 from nkululeko.feat_extract.feats_bert import Bert
 
 
@@ -112,38 +113,38 @@ def test_extract_creates_and_loads_pickle(tmp_path, bert_instance):
 
     bert_instance.util.config_val.side_effect = config_val_mock
 
-    # Mock glob_conf to avoid the 'NoneType' error
-    with patch("nkululeko.feat_extract.feats_bert.glob_conf") as mock_glob_conf:
-        mock_glob_conf.config = {"DATA": {}}
+    # Give the instance a real context so extract()'s
+    # `self.context.config["DATA"][...]` assignment works.
+    bert_instance.context = ExperimentContext(config={"DATA": {}})
 
-        with patch("os.path.isfile", return_value=False):
-            storage = tmp_path / "testbert.pkl"
-            # Remove file if exists
-            if storage.exists():
-                storage.unlink()
-            bert_instance.extract()
-            # Check that the pickle file was created
-            assert storage.exists()
-            assert isinstance(bert_instance.df, pd.DataFrame)
-            assert bert_instance.df.shape[0] == 2  # 2 rows in dummy_data_df
-            assert bert_instance.df.shape[1] == 768  # BERT embedding size
+    with patch("os.path.isfile", return_value=False):
+        storage = tmp_path / "testbert.pkl"
+        # Remove file if exists
+        if storage.exists():
+            storage.unlink()
+        bert_instance.extract()
+        # Check that the pickle file was created
+        assert storage.exists()
+        assert isinstance(bert_instance.df, pd.DataFrame)
+        assert bert_instance.df.shape[0] == 2  # 2 rows in dummy_data_df
+        assert bert_instance.df.shape[1] == 768  # BERT embedding size
 
-        # Now test loading from cache
-        # Mock _needs_extraction to return False (cache hit)
-        with patch.object(type(bert_instance), "_needs_extraction", return_value=False):
-            with patch("os.path.isfile", return_value=True):
-                with patch("pandas.read_pickle") as mock_read_pickle:
-                    cached_df = pd.DataFrame(
-                        {"feat_0": [0.1, 0.2], "feat_1": [0.3, 0.4]}
-                    )
-                    mock_read_pickle.return_value = cached_df
+    # Now test loading from cache
+    # Mock _needs_extraction to return False (cache hit)
+    with patch.object(type(bert_instance), "_needs_extraction", return_value=False):
+        with patch("os.path.isfile", return_value=True):
+            with patch("pandas.read_pickle") as mock_read_pickle:
+                cached_df = pd.DataFrame(
+                    {"feat_0": [0.1, 0.2], "feat_1": [0.3, 0.4]}
+                )
+                mock_read_pickle.return_value = cached_df
 
-                    bert_instance2 = bert_instance
-                    bert_instance2.extract()
+                bert_instance2 = bert_instance
+                bert_instance2.extract()
 
-                    # Verify that pd.read_pickle was called
-                    mock_read_pickle.assert_called_once()
-                    assert isinstance(bert_instance2.df, pd.DataFrame)
+                # Verify that pd.read_pickle was called
+                mock_read_pickle.assert_called_once()
+                assert isinstance(bert_instance2.df, pd.DataFrame)
 
 
 def test_get_embeddings_returns_numpy_array(bert_instance):

--- a/tests/feat_extract/test_feats_opensmile.py
+++ b/tests/feat_extract/test_feats_opensmile.py
@@ -4,7 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ExperimentContext, use_context
 from nkululeko.feat_extract.feats_opensmile import Opensmileset
 
 
@@ -61,8 +61,8 @@ def mock_config():
         "MODEL": {"n_jobs": "1"},
     }
 
-    # Mock the glob_conf.config
-    with patch.object(glob_conf, "config", mock_config):
+    # Mock the active experiment context's config
+    with use_context(ExperimentContext(config=mock_config)):
         yield mock_config
 
 

--- a/tests/feat_extract/test_feats_sptk.py
+++ b/tests/feat_extract/test_feats_sptk.py
@@ -57,20 +57,19 @@ def test_extract_creates_new_features_when_no_cache(sptk_set, mock_util):
     # Mock compute_features to return a DataFrame
     mock_df = pd.DataFrame({"stft_mean": [0.5], "fbank_0_mean": [0.3]})
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                assert result is not None
-                assert isinstance(result, pd.DataFrame)
-                mock_util.debug.assert_any_call(
-                    "extracting SPTK, this might take a while..."
-                )
-                mock_util.write_store.assert_called_once()
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
+            mock_util.debug.assert_any_call(
+                "extracting SPTK, this might take a while..."
+            )
+            mock_util.write_store.assert_called_once()
 
 
 def test_extract_reuses_cached_features(sptk_set, mock_util):
@@ -106,21 +105,20 @@ def test_extract_handles_segmented_index(sptk_set, mock_util):
 
     mock_df = pd.DataFrame({"stft_mean": [0.5]})
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ) as mock_compute:
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ) as mock_compute:
+            result = sptk_set.extract()
 
-                assert result is not None
-                assert isinstance(result, pd.DataFrame)
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
 
-                # Verify compute_features was called with segmented index
-                mock_compute.assert_called_once()
-                call_kwargs = mock_compute.call_args[1]
-                assert "file_index" in call_kwargs
+            # Verify compute_features was called with segmented index
+            mock_compute.assert_called_once()
+            call_kwargs = mock_compute.call_args[1]
+            assert "file_index" in call_kwargs
 
 
 def test_extract_pads_short_signals(sptk_set, mock_util):
@@ -137,17 +135,16 @@ def test_extract_pads_short_signals(sptk_set, mock_util):
 
     mock_df = pd.DataFrame({"stft_mean": [0.5]})
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                # Verify extraction completed successfully
-                assert result is not None
-                assert isinstance(result, pd.DataFrame)
+            # Verify extraction completed successfully
+            assert result is not None
+            assert isinstance(result, pd.DataFrame)
 
 
 def test_extract_computes_stft_statistics(sptk_set, mock_util):
@@ -166,18 +163,17 @@ def test_extract_computes_stft_statistics(sptk_set, mock_util):
         {"stft_mean": [1.5], "stft_std": [0.5], "stft_min": [1.0], "stft_max": [2.0]}
     )
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                assert "stft_mean" in result.columns
-                assert "stft_std" in result.columns
-                assert "stft_min" in result.columns
-                assert "stft_max" in result.columns
+            assert "stft_mean" in result.columns
+            assert "stft_std" in result.columns
+            assert "stft_min" in result.columns
+            assert "stft_max" in result.columns
 
 
 def test_extract_computes_fbank_features(sptk_set, mock_util):
@@ -194,17 +190,16 @@ def test_extract_computes_fbank_features(sptk_set, mock_util):
 
     mock_df = pd.DataFrame({"fbank_0_mean": [0.5], "fbank_1_mean": [0.3]})
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                # Check that FBANK features were computed
-                fbank_cols = [col for col in result.columns if col.startswith("fbank_")]
-                assert len(fbank_cols) > 0
+            # Check that FBANK features were computed
+            fbank_cols = [col for col in result.columns if col.startswith("fbank_")]
+            assert len(fbank_cols) > 0
 
 
 def test_extract_fills_nan_values(sptk_set, mock_util):
@@ -226,16 +221,15 @@ def test_extract_fills_nan_values(sptk_set, mock_util):
     )
 
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                # Verify no NaN values in result
-                assert not result.isnull().values.any()
+            # Verify no NaN values in result
+            assert not result.isnull().values.any()
 
 
 def test_extract_error_on_cached_nan_values(sptk_set, mock_util):
@@ -265,14 +259,13 @@ def test_extract_converts_to_float(sptk_set, mock_util):
 
     mock_df = pd.DataFrame({"stft_mean": [0.5]})
     with patch("nkululeko.feat_extract.feats_sptk.os.path.isfile", return_value=False):
-        with patch("nkululeko.feat_extract.feats_sptk.glob_conf") as mock_glob_conf:
-            mock_glob_conf.config = {"DATA": {}}
-            with patch(
-                "nkululeko.feat_extract.feats_sptk_core.compute_features",
-                return_value=mock_df,
-            ):
-                result = sptk_set.extract()
+        sptk_set.context.config = {"DATA": {}}
+        with patch(
+            "nkululeko.feat_extract.feats_sptk_core.compute_features",
+            return_value=mock_df,
+        ):
+            result = sptk_set.extract()
 
-                # Verify all columns are float
-                for col in result.columns:
-                    assert result[col].dtype == np.float64
+            # Verify all columns are float
+            for col in result.columns:
+                assert result[col].dtype == np.float64

--- a/tests/reporting/test_reporter.py
+++ b/tests/reporting/test_reporter.py
@@ -103,3 +103,31 @@ class TestReporterEmpty:
         r = Reporter([], [], run=0, epoch=0)
         result = r.get_result()
         assert result.test == 0
+
+
+class TestReporterClassificationReportMismatch:
+    """classification_report raises ValueError when target_names doesn't
+    match the classes actually present in truths/preds (e.g. a class never
+    predicted). print_results must degrade gracefully instead of crashing.
+    """
+
+    def test_print_results_falls_back_without_crashing(self, tmp_path):
+        glob_conf.config["EXP"]["root"] = str(tmp_path)
+        truths = np.array([0, 1] * 5)
+        preds = np.array([0, 1] * 5)
+        r = Reporter(truths, preds, run=0, epoch=0)
+        # print_results() prefers label_encoder.classes_ over context.labels
+        # when a label_encoder is present; clear it so this test deterministically
+        # exercises the context.labels path regardless of what other tests left
+        # on the shared context.
+        r.context.label_encoder = None
+        # Claim more labels than actually appear in truths/preds so
+        # classification_report raises ValueError.
+        r.context.labels = ["a", "b", "c", "d", "e"]
+
+        r.print_results(epoch=0, file_name="mismatch_test")
+
+        res_dir = r.util.get_path("res_dir")
+        with open(res_dir + "mismatch_test.txt") as f:
+            content = f.read()
+        assert "UAR" in content

--- a/tests/test_bundle_infer.py
+++ b/tests/test_bundle_infer.py
@@ -350,11 +350,10 @@ class TestPredictFromBundle:
 
 
 class TestSetupGlobConf:
-    """Test _setup_context initializes the experiment context properly."""
+    """Test _setup_context builds a correctly configured experiment context."""
 
     def test_basic_setup(self):
         from nkululeko.infer import _setup_context
-        import nkululeko.glob_conf as glob_conf
 
         config = configparser.ConfigParser()
         config["DATA"] = {"target": "emotion"}
@@ -367,16 +366,13 @@ class TestSetupGlobConf:
             "manifest": {"labels": ["anger", "joy"]},
         }
 
-        # _setup_context calls set_context(), which swaps the process-wide
-        # active context; restore it afterward so later tests aren't affected.
-        previous_context = glob_conf.get_context()
-        try:
-            _setup_context(bundle)
+        # _setup_context only builds the context now — it no longer mutates
+        # process-wide state, so there's nothing to save/restore.
+        context = _setup_context(bundle)
 
-            assert glob_conf.config is not None
-            assert glob_conf.config["DATA"]["target"] == "emotion"
-        finally:
-            glob_conf.set_context(previous_context)
+        assert context.config is not None
+        assert context.config["DATA"]["target"] == "emotion"
+        assert context.labels == ["anger", "joy"]
 
 
 class TestFindAudioFiles:

--- a/tests/test_bundle_infer.py
+++ b/tests/test_bundle_infer.py
@@ -350,10 +350,10 @@ class TestPredictFromBundle:
 
 
 class TestSetupGlobConf:
-    """Test _setup_glob_conf initializes global config properly."""
+    """Test _setup_context initializes the experiment context properly."""
 
     def test_basic_setup(self):
-        from nkululeko.infer import _setup_glob_conf
+        from nkululeko.infer import _setup_context
         import nkululeko.glob_conf as glob_conf
 
         config = configparser.ConfigParser()
@@ -367,10 +367,16 @@ class TestSetupGlobConf:
             "manifest": {"labels": ["anger", "joy"]},
         }
 
-        _setup_glob_conf(bundle)
+        # _setup_context calls set_context(), which swaps the process-wide
+        # active context; restore it afterward so later tests aren't affected.
+        previous_context = glob_conf.get_context()
+        try:
+            _setup_context(bundle)
 
-        assert glob_conf.config is not None
-        assert glob_conf.config["DATA"]["target"] == "emotion"
+            assert glob_conf.config is not None
+            assert glob_conf.config["DATA"]["target"] == "emotion"
+        finally:
+            glob_conf.set_context(previous_context)
 
 
 class TestFindAudioFiles:

--- a/tests/test_experiment.py
+++ b/tests/test_experiment.py
@@ -1,5 +1,7 @@
 import pytest
 import configparser
+import copy
+import pickle
 import random
 import tempfile
 import pandas as pd
@@ -43,6 +45,44 @@ class TestExperimentSetGlobals:
         glob_conf.init_config(mock_config)
         glob_conf.set_module("test")
         assert glob_conf.module == "test"
+
+    def test_experiments_keep_contexts_separate(self, mock_config, tmp_path):
+        """Method calls reactivate the owning experiment context."""
+        from nkululeko.experiment import Experiment
+
+        first_config = mock_config
+        first_config["EXP"]["name"] = "first"
+        first_config["EXP"]["root"] = str(tmp_path)
+        second_config = copy.deepcopy(first_config)
+        second_config["EXP"]["name"] = "second"
+
+        first = Experiment(first_config)
+        second = Experiment(second_config)
+        first.set_module("first-module")
+        second.set_module("second-module")
+
+        assert first.context.config["EXP"]["name"] == "first"
+        assert second.context.config["EXP"]["name"] == "second"
+        assert first.context.module == "first-module"
+        assert second.context.module == "second-module"
+
+    def test_load_preserves_receiving_context(self, mock_config, tmp_path):
+        """Loading saved state must retain the configuration used to load it."""
+        from nkululeko.experiment import Experiment
+        from nkululeko.utils.pickle_integrity import save_checksum
+
+        experiment = Experiment(mock_config)
+        context = experiment.context
+        saved_context = glob_conf.ExperimentContext(config={"stale": True})
+        save_path = tmp_path / "experiment.pkl"
+        with open(save_path, "wb") as file:
+            pickle.dump({"context": saved_context, "labels": ["happy"]}, file)
+        save_checksum(str(save_path))
+
+        experiment.load(str(save_path))
+
+        assert experiment.context is context
+        assert experiment.context.config is mock_config
 
 
 class TestExperimentImportCsv:

--- a/tests/test_flags.py
+++ b/tests/test_flags.py
@@ -269,18 +269,22 @@ def test_explore_module_with_name_target():
 def _make_analyser(tmp_path):
     """Build a FeatureAnalyser with minimal fakes."""
     import pandas as pd
+    from nkululeko.experiment_context import ExperimentContext
     from nkululeko.feat_extract.feats_analyser import FeatureAnalyser
 
     features = pd.DataFrame({"f1": [1.0, 2.0, 3.0], "f2": [4.0, 5.0, 6.0]})
     labels = pd.DataFrame({"emotion": ["a", "b", "a"]})
 
+    context = ExperimentContext(
+        config={"DATA": {"target": "emotion"}, "EXP": {"root": str(tmp_path), "name": "t"}}
+    )
+
     with (
-        patch("nkululeko.glob_conf.config", {"DATA": {"target": "emotion"}, "EXP": {"root": str(tmp_path), "name": "t"}}),
         patch("nkululeko.utils.util.Util.get_path", return_value=str(tmp_path) + "/"),
         patch("nkululeko.utils.util.Util.config_val", side_effect=lambda s, k, d=None: "emotion" if k == "target" else d),
         patch("nkululeko.plots.Plots.__init__", return_value=None),
     ):
-        return FeatureAnalyser("train", labels, features)
+        return FeatureAnalyser("train", labels, features, context=context)
 
 
 def test_get_importance_caches_result(tmp_path):

--- a/tests/test_glob_conf.py
+++ b/tests/test_glob_conf.py
@@ -1,4 +1,15 @@
+from concurrent.futures import ThreadPoolExecutor
+
 import nkululeko.glob_conf as glob_conf
+
+
+@glob_conf.bind_experiment_context
+class _ContextBoundExperiment:
+    def __init__(self, name):
+        self.context = glob_conf.ExperimentContext(config={"name": name})
+
+    def set_module(self, module):
+        glob_conf.set_module(module)
 
 
 class TestGlobConf:
@@ -125,3 +136,57 @@ class TestGlobConf:
         assert glob_conf.report is None
         assert glob_conf.labels is None
         assert glob_conf.target is None
+
+    def test_contexts_are_isolated_across_threads(self):
+        """Each experiment context keeps its state during concurrent work."""
+        first = glob_conf.ExperimentContext(config={"name": "first"})
+        second = glob_conf.ExperimentContext(config={"name": "second"})
+
+        def read_context(context, module):
+            with glob_conf.use_context(context):
+                glob_conf.set_module(module)
+                return glob_conf.config["name"], glob_conf.module
+
+        with ThreadPoolExecutor(max_workers=2) as executor:
+            results = list(
+                executor.map(
+                    lambda args: read_context(*args),
+                    ((first, "first-module"), (second, "second-module")),
+                )
+            )
+
+        assert results == [("first", "first-module"), ("second", "second-module")]
+        assert first.module == "first-module"
+        assert second.module == "second-module"
+
+    def test_bound_methods_activate_their_experiment_context(self):
+        """Context binding prevents sequential experiments leaking state."""
+        first = _ContextBoundExperiment("first")
+        second = _ContextBoundExperiment("second")
+
+        first.set_module("first-module")
+        second.set_module("second-module")
+
+        assert first.context.module == "first-module"
+        assert second.context.module == "second-module"
+
+    def test_set_context_selects_an_experiment_context(self):
+        """The compatibility facade supports existing orchestration code."""
+        context = glob_conf.ExperimentContext(config={"name": "selected"})
+        previous_context = glob_conf.get_context()
+
+        try:
+            glob_conf.set_context(context)
+
+            assert glob_conf.config == {"name": "selected"}
+        finally:
+            glob_conf.set_context(previous_context)
+
+    def test_wildcard_import_includes_legacy_state_attributes(self):
+        """The migration facade preserves the legacy wildcard import surface."""
+        namespace = {}
+
+        exec("from nkululeko.glob_conf import *", namespace)
+
+        assert "config" in namespace
+        assert "labels" in namespace

--- a/tests/test_nkululeko.py
+++ b/tests/test_nkululeko.py
@@ -9,6 +9,8 @@ import numpy as np
 import pandas as pd
 from sklearn.preprocessing import LabelEncoder
 
+from nkululeko.experiment_context import ExperimentContext
+
 
 class DummyReport:
     class Result:
@@ -30,7 +32,7 @@ class DummyRunmanager:
 
 class DummyExperiment:
     def __init__(self, config):
-        self.config = config
+        self.context = ExperimentContext(config=config)
         self.name = config.get("EXP", "name", fallback="test")
         self.runmgr = DummyRunmanager()
         self.reports = [DummyReport()]
@@ -193,6 +195,7 @@ class TestNkululekoFastPath:
                     self.name = "test_exp"
                     # Initialise glob_conf so Util.config_val/get_save_name work.
                     nk_glob_conf.init_config(cfg)
+                    self.context = nk_glob_conf.get_context()
                     self.label_encoder = le
                     self.target = "emotion"
                     self.labels = ["happy", "sad"]

--- a/tests/test_optim.py
+++ b/tests/test_optim.py
@@ -1,6 +1,7 @@
 import pytest
 import numpy as np
 from unittest.mock import MagicMock, patch
+from nkululeko.experiment_context import ExperimentContext, use_context
 from nkululeko.optim import OptimizationRunner
 
 
@@ -107,7 +108,7 @@ def test_run_sklearn_optimization_grid(runner, param_specs):
         patch("nkululeko.experiment.Experiment", return_value=mock_expr),
         patch("sklearn.model_selection.GridSearchCV", return_value=mock_search),
         patch("nkululeko.modelrunner.Modelrunner") as mock_Modelrunner,
-        patch("nkululeko.glob_conf.config", runner.config),
+        use_context(ExperimentContext(config=runner.config)),
     ):
         mock_runner_inst = MagicMock()
         mock_runner_inst.model.clf = MagicMock()
@@ -140,7 +141,7 @@ def test_run_sklearn_optimization_random(runner, param_specs):
         patch("nkululeko.experiment.Experiment", return_value=mock_expr),
         patch("sklearn.model_selection.RandomizedSearchCV", return_value=mock_search),
         patch("nkululeko.modelrunner.Modelrunner") as mock_Modelrunner,
-        patch("nkululeko.glob_conf.config", runner.config),
+        use_context(ExperimentContext(config=runner.config)),
     ):
         mock_runner_inst = MagicMock()
         mock_runner_inst.model.clf = MagicMock()
@@ -199,7 +200,7 @@ def test_run_sklearn_optimization_grid_strategy(runner, param_specs):
             "sklearn.model_selection.GridSearchCV", return_value=mock_search
         ) as mock_GridSearchCV,
         patch("nkululeko.modelrunner.Modelrunner") as mock_Modelrunner,
-        patch("nkululeko.glob_conf.config", runner.config),
+        use_context(ExperimentContext(config=runner.config)),
     ):
         mock_runner_inst = MagicMock()
         mock_runner_inst.model.clf = MagicMock()

--- a/tests/test_scaler.py
+++ b/tests/test_scaler.py
@@ -5,7 +5,7 @@ from nkululeko.scaler import Scaler
 
 
 class DummyUtil:
-    def __init__(self, name):
+    def __init__(self, name, context=None):
         pass
 
     def error(self, msg):


### PR DESCRIPTION
This is a big PR to solve issue [#37](https://github.com/bagustris/nkululeko/issues/37) (architectural changes for glob_conf).

### Summary 
Main changes: Thread ExperimentContext through orchestration objects (use_context / ContextAware) instead of global glob_conf state, so nkululeko can be used as a library.

Merges the experiment-scoped context refactor  [#37](https://github.com/bagustris/nkululeko/issues/37) with main's independent fixes since the branches diverged:
  - SonarQube model-validation functions (main's fix  [#39](https://github.com/bagustris/nkululeko/issues/39))
  - Logger handler race condition (main's fix [#58](https://github.com/bagustris/nkululeko/pull/58))
  - Flag-propagation and label-encoding improvements

  This resolves the global mutable state (`glob_conf`) that blocks parallel experiment runs and makes unit testing difficult, replacing it with an injected `ExperimentContext` threaded through the object hierarchy.

  ## Conflict Resolution

  Three files had real import conflicts; resolved by union:
  - **dataset.py, datasplitter.py, modelrunner.py**: kept main's newer logic (validation functions, threading lock, label-encoding fallback)  plus refactor's required `ContextAware`/`experiment_context` imports, since auto-merged method bodies depend on both

  ## Test Updates

  Fixed ~15 test files broken by the refactor's API changes:
  - **autopredict/test_ap_*.py**: DummyUtil mocks updated to accept `context`; tests wrapped in `use_context()` 
  - **test_scaler.py, test_flags.py, test_optim.py**: patches replaced from `patch("...glob_conf.config")` to 
  `use_context(ExperimentContext(...))` (the compat shim's custom module `__setattr__`/`__delattr__` is incompatible with unittest.mock's  save/restore)
  - **test_nkululeko.py, test_bundle_infer.py**: fake Experiment classes given `.context` attribute; global-context leaks fixed via 
  save/restore
  - **feats_sptk/opensmile/bert**: same glob_conf patch issue fixed; also added missing test for `_setup_context()`

  ## Bonus: Pre-existing Bug Fix

  Fixed a pre-existing error-handling bug in `reporter.py` where exception concatenation (`"string" + e`) raised `TypeError`, masking the original error. The fallback path now handles gracefully when `classification_report()` fails due to class label mismatches.

  ## Verification

  - **Full test suite**: 948 passed, 3 skipped, 0 failed
  - **End-to-end experiment**: ran real Polish emotion dataset (452 audio files, opensmile + xgb, speaker-disjoint splits) — completed cleanly, UAR 0.467
  - **Reporter fix validated**: re-triggered the exact `classification_report` ValueError scenario that crashed before; confirmed graceful degradation with sane result file 