### PR TITLE
fix bug to re-open best model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.8.3 (26-08-16)
+------------------------
+* fux bug: best model reload
+
 Version 1.8.2 (26-08-16)
 ------------------------
 * fix bug: pytorch save 

--- a/docs/source/config_defaults_reference.md
+++ b/docs/source/config_defaults_reference.md
@@ -9,7 +9,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'DATA'.'target'`: `'emotion'` (nkululeko/augment.py:81), `'emotion'` (nkululeko/augmenting/resampler.py:76), `'emotion'` (nkululeko/bundle.py:56), `'emotion'` (nkululeko/bundle.py:218), `None` (nkululeko/data/dataset.py:34), `None` (nkululeko/data/dataset_csv.py:84), `None` (nkululeko/experiment.py:123), `'emotion'` (nkululeko/experiment.py:631), `'emotion'` (nkululeko/experiment.py:641), `'emotion'` (nkululeko/experiment.py:651), `'emotion'` (nkululeko/export.py:108), `'emotion'` (nkululeko/feat_extract/feats_analyser.py:26), `'emotion'` (nkululeko/models/model.py:34), `'emotion'` (nkululeko/plots.py:31), `'class_label'` (nkululeko/plots.py:893), `'emotion'` (nkululeko/testing_predictor.py:71), `None` (nkululeko/utils/util.py:606)
 * `'DATA'.'tests'`: `'False'` (nkululeko/data/dataset.py:703), `False` (nkululeko/nkululeko.py:46), `False` (nkululeko/testing_predictor.py:59)
 * `'DATA'.'type'`: `False` (nkululeko/data/dataset.py:795), `'dummy'` (nkululeko/data/datasplitter.py:189)
-* `'EXP'.'epochs'`: `1` (nkululeko/modelrunner.py:124), `1` (nkululeko/models/model_tuned.py:65), `'50'` (nkululeko/optimizers/scheduler_factory.py:84)
+* `'EXP'.'epochs'`: `1` (nkululeko/modelrunner.py:129), `1` (nkululeko/models/model_tuned.py:65), `'50'` (nkululeko/optimizers/scheduler_factory.py:84)
 * `'EXP'.'language'`: `'en'` (nkululeko/autopredict/ap_text.py:31), `False` (nkululeko/bundle.py:101)
 * `'EXP'.'sample_selection'`: `'all'` (nkululeko/data/datasplitter.py:31), `'train'` (nkululeko/experiment.py:490), `'all'` (nkululeko/experiment.py:511), `'all'` (nkululeko/feat_extract/feats_analyser.py:388), `'all'` (nkululeko/plots.py:636), `'all'` (nkululeko/predict.py:543), `'all'` (nkululeko/resample.py:127), `'all'` (nkululeko/segment.py:242)
 * `'EXP'.'type'`: `None` (nkululeko/data/dataset.py:146), `'classification'` (nkululeko/utils/util.py:297)
@@ -27,7 +27,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'MODEL'.'drop'`: `False` (nkululeko/models/model_cnn.py:57), `False` (nkululeko/models/model_cnn.py:235), `False` (nkululeko/models/model_cnn.py:252), `'False'` (nkululeko/models/model_mlp.py:53), `'False'` (nkululeko/models/model_mlp.py:274), `'False'` (nkululeko/models/model_mlp.py:307), `False` (nkululeko/models/model_mlp_regression.py:55), `False` (nkululeko/models/model_mlp_regression.py:253), `False` (nkululeko/models/model_mlp_regression.py:272), `False` (nkululeko/models/model_tuned.py:67)
 * `'MODEL'.'learning_rate'`: `'0.0001'` (nkululeko/models/model_tuned.py:61), `0.3` (nkululeko/models/model_xgb.py:32), `str(default_lr)` (nkululeko/optimizers/optimizer_factory.py:32)
 * `'MODEL'.'loss'`: `'cross'` (nkululeko/models/model.py:93), `'bce'` (nkululeko/models/model_adm.py:65), `'mse'` (nkululeko/models/model_mlp_regression.py:29), `'cross'` (nkululeko/models/model_tuned.py:434), `'1-ccc'` (nkululeko/models/model_tuned.py:453)
-* `'MODEL'.'measure'`: `'mse'` (nkululeko/models/model_mlp_regression.py:232), `'ccc'` (nkululeko/models/model_tuned.py:56), `'uar'` (nkululeko/reporting/reporter.py:81), `'mse'` (nkululeko/reporting/reporter.py:92), `'mse'` (nkululeko/reporting/reporter.py:636), `'uar'` (nkululeko/reporting/run_plotter.py:79), `'uar'` (nkululeko/runmanager.py:161), `'uar'` (nkululeko/utils/util.py:615), `'mse'` (nkululeko/utils/util.py:622)
+* `'MODEL'.'measure'`: `'mse'` (nkululeko/models/model_mlp_regression.py:232), `'ccc'` (nkululeko/models/model_tuned.py:56), `'uar'` (nkululeko/reporting/reporter.py:81), `'mse'` (nkululeko/reporting/reporter.py:92), `'mse'` (nkululeko/reporting/reporter.py:636), `'uar'` (nkululeko/reporting/run_plotter.py:79), `'uar'` (nkululeko/runmanager.py:166), `'uar'` (nkululeko/utils/util.py:615), `'mse'` (nkululeko/utils/util.py:622)
 * `'MODEL'.'scheduler.gamma'`: `'0.5'` (nkululeko/optimizers/scheduler_factory.py:46), `'0.95'` (nkululeko/optimizers/scheduler_factory.py:54)
 * `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:118)
 * `'REPORT'.'latex'`: `False` (nkululeko/experiment.py:90), `'nkululeko_latex'` (nkululeko/reporting/latex_writer.py:39)
@@ -64,18 +64,18 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:52 |
 | 'DATA' | 'type' | `'dummy'` / `False` | nkululeko/data/dataset.py:795, nkululeko/data/datasplitter.py:189 |
 | 'DATA' | <f'{stratif_var}_bins'> | `False` | nkululeko/data/dataset.py:529 |
-| 'EXP' | 'balancing' | `False` | nkululeko/modelrunner.py:251 |
-| 'EXP' | 'epochs' | `'50'` / `1` | nkululeko/modelrunner.py:124, nkululeko/models/model_tuned.py:65, nkululeko/optimizers/scheduler_factory.py:84 |
+| 'EXP' | 'balancing' | `False` | nkululeko/modelrunner.py:256 |
+| 'EXP' | 'epochs' | `'50'` / `1` | nkululeko/modelrunner.py:129, nkululeko/models/model_tuned.py:65, nkululeko/optimizers/scheduler_factory.py:84 |
 | 'EXP' | 'export_onnx' | `'False'` | nkululeko/nkululeko.py:131 |
 | 'EXP' | 'filter.sample_selection' | `'all'` | nkululeko/data/datasplitter.py:155 |
 | 'EXP' | 'language' | `'en'` / `False` | nkululeko/autopredict/ap_text.py:31, nkululeko/bundle.py:101 |
 | 'EXP' | 'no_warnings' | `False` | nkululeko/aug_train.py:35, nkululeko/augment.py:36, nkululeko/explore.py:62, +5 more |
 | 'EXP' | 'run' | `0` | nkululeko/utils/util.py:217 |
-| 'EXP' | 'runs' | `1` | nkululeko/experiment.py:743, nkululeko/reporting/run_plotter.py:43, nkululeko/runmanager.py:61 |
+| 'EXP' | 'runs' | `1` | nkululeko/experiment.py:743, nkululeko/reporting/run_plotter.py:43, nkululeko/runmanager.py:66 |
 | 'EXP' | 'sample_selection' | `'all'` / `'train'` | nkululeko/data/datasplitter.py:31, nkululeko/experiment.py:490, nkululeko/experiment.py:511, +5 more |
 | 'EXP' | 'save' | `True` | nkululeko/experiment.py:720 |
 | 'EXP' | 'save_test' | `False` | nkululeko/experiment.py:730 |
-| 'EXP' | 'traindevtest' | `'False'` | nkululeko/experiment.py:54, nkululeko/models/model_xgb.py:74, nkululeko/runmanager.py:54 |
+| 'EXP' | 'traindevtest' | `'False'` | nkululeko/experiment.py:54, nkululeko/models/model_xgb.py:74, nkululeko/runmanager.py:59 |
 | 'EXP' | 'type' | `'classification'` / `None` | nkululeko/data/dataset.py:146, nkululeko/utils/util.py:297 |
 | 'EXPL' | 'dist_type' | `'hist'` / `'kde'` | nkululeko/plots.py:149, nkululeko/plots.py:425 |
 | 'EXPL' | 'feature_distributions' | `'False'` | nkululeko/experiment.py:509, nkululeko/explore.py:85 |
@@ -111,8 +111,8 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'FEATS' | 'aud.model' | `'./audmodel/'` | nkululeko/feat_extract/feats_auddim.py:27, nkululeko/feat_extract/feats_audwav2vec2.py:31 |
 | 'FEATS' | 'audmodel.embeddings_name' | `'hidden_states'` | nkululeko/feat_extract/feats_audmodel.py:39 |
 | 'FEATS' | 'audmodel.id' | `'audmodel'` / `False` | nkululeko/feat_extract/feats_audmodel.py:34, nkululeko/feat_extract/feats_audmodel.py:167 |
-| 'FEATS' | 'balancing' | `False` | nkululeko/modelrunner.py:373 |
-| 'FEATS' | 'balancing_random_state' | `42` | nkululeko/modelrunner.py:379 |
+| 'FEATS' | 'balancing' | `False` | nkululeko/modelrunner.py:378 |
+| 'FEATS' | 'balancing_random_state' | `42` | nkululeko/modelrunner.py:384 |
 | 'FEATS' | 'bert.layer' | `'0'` | nkululeko/feat_extract/feats_bert.py:39 |
 | 'FEATS' | 'bert.model' | `f'{self.feat_type}'` | nkululeko/feat_extract/feats_bert.py:31, nkululeko/feat_extract/feats_bert.py:79 |
 | 'FEATS' | 'bert.text_column' | `'text'` | nkululeko/feat_extract/feats_bert.py:57 |
@@ -196,13 +196,13 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'n_estimators' | `100` | nkululeko/models/model_xgb.py:30 |
 | 'MODEL' | 'n_jobs' | `'8'` | nkululeko/feat_extract/featureset.py:34, nkululeko/models/model.py:39 |
 | 'MODEL' | 'nan_strategy' | `'zero'` | nkululeko/models/model.py:380 |
-| 'MODEL' | 'only_test' | `False` | nkululeko/modelrunner.py:123 |
+| 'MODEL' | 'only_test' | `False` | nkululeko/modelrunner.py:128 |
 | 'MODEL' | 'optimizer' | `default_optimizer` | nkululeko/optimizers/optimizer_factory.py:33 |
-| 'MODEL' | 'patience' | `False` | nkululeko/modelrunner.py:129 |
+| 'MODEL' | 'patience' | `False` | nkululeko/modelrunner.py:134 |
 | 'MODEL' | 'pretrained_model' | `model_path` | nkululeko/models/model_tuned.py:78 |
 | 'MODEL' | 'push_to_hub' | `'False'` | nkululeko/models/model_tuned.py:72 |
 | 'MODEL' | 'random_seed' | `'False'` | nkululeko/models/model_adm.py:51, nkululeko/models/model_mlp.py:33, nkululeko/models/model_mlp_regression.py:42 |
-| 'MODEL' | 'save' | `'True'` | nkululeko/modelrunner.py:192 |
+| 'MODEL' | 'save' | `'True'` | nkululeko/modelrunner.py:197 |
 | 'MODEL' | 'scheduler' | `default_scheduler` | nkululeko/optimizers/scheduler_factory.py:37 |
 | 'MODEL' | 'scheduler.gamma' | `'0.5'` / `'0.95'` | nkululeko/optimizers/scheduler_factory.py:46, nkululeko/optimizers/scheduler_factory.py:54 |
 | 'MODEL' | 'scheduler.step_size' | `'10'` | nkululeko/optimizers/scheduler_factory.py:45 |
@@ -213,16 +213,16 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'validation_split' | `0.2` | nkululeko/models/model_xgb.py:99 |
 | 'MODEL' | 'warmup_epochs' | `'5'` | nkululeko/optimizers/scheduler_factory.py:86 |
 | 'MODEL' | 'weight_decay' | `'0.01'` | nkululeko/optimizers/optimizer_factory.py:36 |
-| 'PLOT' | 'anim_progression' | `0` | nkululeko/runmanager.py:102 |
+| 'PLOT' | 'anim_progression' | `0` | nkululeko/runmanager.py:107 |
 | 'PLOT' | 'ccc' | `'False'` | nkululeko/plots.py:32 |
 | 'PLOT' | 'combine_per_speaker' | `False` | nkululeko/experiment.py:735 |
-| 'PLOT' | 'epoch_progression' | `0` | nkululeko/runmanager.py:111 |
-| 'PLOT' | 'epochs' | `False` | nkululeko/modelrunner.py:122 |
+| 'PLOT' | 'epoch_progression' | `0` | nkululeko/runmanager.py:116 |
+| 'PLOT' | 'epochs' | `False` | nkululeko/modelrunner.py:127 |
 | 'PLOT' | 'fill_areas' | `'False'` | nkululeko/plots.py:426 |
 | 'PLOT' | 'format' | `'png'` | nkululeko/feat_extract/feats_analyser.py:141, nkululeko/feat_extract/feats_analyser.py:339, nkululeko/plots.py:30, +2 more |
 | 'PLOT' | 'fps' | `'1'` | nkululeko/reporting/reporter.py:650 |
 | 'PLOT' | 'kind' | `'violin'` | nkululeko/plots.py:786 |
-| 'PLOT' | 'name' | `plot_name_suggest` | nkululeko/experiment.py:287, nkululeko/reporting/reporter.py:663, nkululeko/runmanager.py:95, +7 more |
+| 'PLOT' | 'name' | `plot_name_suggest` | nkululeko/experiment.py:287, nkululeko/reporting/reporter.py:663, nkululeko/runmanager.py:100, +7 more |
 | 'PLOT' | 'runs_compare' | `False` | nkululeko/experiment.py:742 |
 | 'PLOT' | 'titles' | `'True'` | nkululeko/plots.py:34, nkululeko/reporting/run_plotter.py:21 |
 | 'PLOT' | 'uncertainty_threshold' | `False` | nkululeko/reporting/reporter.py:283 |

--- a/nkululeko/constants.py
+++ b/nkululeko/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.8.2"
+VERSION = "1.8.3"
 SAMPLING_RATE = 16000
 COL_SEX = "gender"
 COL_AGE = "age"

--- a/nkululeko/modelrunner.py
+++ b/nkululeko/modelrunner.py
@@ -3,7 +3,11 @@
 import ast
 
 from nkululeko.balance import DataBalancer
-from nkululeko.experiment_context import ContextAware, use_context
+from nkululeko.experiment_context import (
+    ContextAware,
+    bind_experiment_context,
+    use_context,
+)
 from nkululeko.utils.util import Util
 
 # Fallback type-based heuristics used when a model instance is not yet available
@@ -71,6 +75,7 @@ def _check_task_capability(
         )
 
 
+@bind_experiment_context
 class Modelrunner(ContextAware):
     """Class to model one run."""
 

--- a/nkululeko/runmanager.py
+++ b/nkululeko/runmanager.py
@@ -4,12 +4,17 @@ This module contains the Runmanager class which is responsible for managing the
 runs of the experiment.
 """
 
-from nkululeko.experiment_context import ContextAware, use_context
+from nkululeko.experiment_context import (
+    ContextAware,
+    bind_experiment_context,
+    use_context,
+)
 from nkululeko.modelrunner import Modelrunner
 from nkululeko.reporting.reporter import Reporter
 from nkululeko.utils.util import Util
 
 
+@bind_experiment_context
 class Runmanager(ContextAware):
     """Class to manage the runs of the experiment (e.g. when results differ caused by random initialization)."""
 

--- a/tests/test_runmanager.py
+++ b/tests/test_runmanager.py
@@ -132,6 +132,7 @@ class TestLoadModelContextPropagation:
 
         # Mimic predict.py: a freshly built Experiment made `context_live`
         # ambient, unrelated to the reloaded, training-time `context_train`.
+        previous_context = get_context()
         set_context(context_live)
 
         runmgr = Runmanager.__new__(Runmanager)
@@ -152,7 +153,7 @@ class TestLoadModelContextPropagation:
 
         report = types.SimpleNamespace(run=1, epoch=4)
         runmgr.load_model(report)
-
+        set_context(previous_context)
         # load_model's set_config_val("EXP", "run", 1) must be visible to
         # the nested _select_model call via the ambient context.
         assert observed_run["run"] == "1"

--- a/tests/test_runmanager.py
+++ b/tests/test_runmanager.py
@@ -6,7 +6,7 @@ import types
 import pytest
 
 import nkululeko.glob_conf as glob_conf
-from nkululeko.experiment_context import ExperimentContext, get_context, set_context
+from nkululeko.experiment_context import ExperimentContext, get_context, use_context
 from nkululeko.runmanager import Runmanager
 from nkululeko.utils.util import Util
 
@@ -130,11 +130,6 @@ class TestLoadModelContextPropagation:
         context_train = self._make_context(run="0")
         context_live = self._make_context(run="0")
 
-        # Mimic predict.py: a freshly built Experiment made `context_live`
-        # ambient, unrelated to the reloaded, training-time `context_train`.
-        previous_context = get_context()
-        set_context(context_live)
-
         runmgr = Runmanager.__new__(Runmanager)
         runmgr.context = context_train
         runmgr.util = Util("runmanager", context=context_train)
@@ -150,10 +145,15 @@ class TestLoadModelContextPropagation:
                 return types.SimpleNamespace(load=lambda run, epoch: None)
 
         runmgr.modelrunner = _FakeModelrunner()
-
         report = types.SimpleNamespace(run=1, epoch=4)
-        runmgr.load_model(report)
-        set_context(previous_context)
+
+        # Mimic predict.py: a freshly built Experiment made `context_live`
+        # ambient, unrelated to the reloaded, training-time `context_train`.
+        # Scoped with `use_context` (the codebase's own idiom) so the ambient
+        # context is restored via its token even if load_model raises.
+        with use_context(context_live):
+            runmgr.load_model(report)
+
         # load_model's set_config_val("EXP", "run", 1) must be visible to
         # the nested _select_model call via the ambient context.
         assert observed_run["run"] == "1"
@@ -163,7 +163,6 @@ class TestLoadModelContextPropagation:
     def test_load_model_restores_prior_ambient_context_afterwards(self):
         context_train = self._make_context(run="0")
         context_live = self._make_context(run="0")
-        set_context(context_live)
 
         runmgr = Runmanager.__new__(Runmanager)
         runmgr.context = context_train
@@ -174,11 +173,14 @@ class TestLoadModelContextPropagation:
             )
         )
 
-        runmgr.load_model(types.SimpleNamespace(run=1, epoch=4))
-
-        # Ambient context after the call must be back to whatever it was
-        # before -- load_model must not leave context_train installed globally.
-        assert get_context() is context_live
+        with use_context(context_live):
+            runmgr.load_model(types.SimpleNamespace(run=1, epoch=4))
+            # Ambient context after the call must be back to whatever it was
+            # before -- load_model must not leave context_train installed
+            # globally. Asserted inside the `with` so this checks the
+            # use_context scope load_model was invoked in, not some later,
+            # unrelated ambient state.
+            assert get_context() is context_live
 
 
 class TestRunmanagerInit:

--- a/tests/test_runmanager.py
+++ b/tests/test_runmanager.py
@@ -6,7 +6,9 @@ import types
 import pytest
 
 import nkululeko.glob_conf as glob_conf
+from nkululeko.experiment_context import ExperimentContext, get_context, set_context
 from nkululeko.runmanager import Runmanager
+from nkululeko.utils.util import Util
 
 
 @pytest.fixture(autouse=True)
@@ -104,6 +106,78 @@ class TestGetBestResult:
         reports = [_make_report(10.0), _make_report(0.5), _make_report(3.0)]
         best = runmanager.get_best_result(reports)
         assert best.result.test == pytest.approx(0.5)
+
+
+class TestLoadModelContextPropagation:
+    """Regression for the predict/reload path: when a pickled Runmanager
+    (built during training, holding `context_train`) is reactivated under a
+    fresh "live" ambient context (as `predict.py` sets up via a new
+    `Experiment(config)`), `load_model()` must make its own context ambient
+    for the whole call. Otherwise `EXP.run` gets updated on `context_train`
+    but any object constructed deeper (e.g. a model's `Util()` with no
+    explicit context) resolves `get_context()` to the stale, never-updated
+    live context and looks for the model files under `run_0/` even when a
+    later run (e.g. run 1) actually won.
+    """
+
+    def _make_context(self, run="0"):
+        config = configparser.ConfigParser()
+        config["EXP"] = {"run": run}
+        config["MODEL"] = {"type": "xgb"}
+        return ExperimentContext(config=config)
+
+    def test_load_model_makes_own_context_ambient_for_nested_construction(self):
+        context_train = self._make_context(run="0")
+        context_live = self._make_context(run="0")
+
+        # Mimic predict.py: a freshly built Experiment made `context_live`
+        # ambient, unrelated to the reloaded, training-time `context_train`.
+        set_context(context_live)
+
+        runmgr = Runmanager.__new__(Runmanager)
+        runmgr.context = context_train
+        runmgr.util = Util("runmanager", context=context_train)
+
+        observed_run = {}
+
+        class _FakeModelrunner:
+            def _select_model(self, model_type):
+                # Stands in for e.g. MLP_Reg_model's constructor calling
+                # `Util("mlp_reg")` with no explicit context, which falls
+                # back to `get_context()`.
+                observed_run["run"] = get_context().config["EXP"]["run"]
+                return types.SimpleNamespace(load=lambda run, epoch: None)
+
+        runmgr.modelrunner = _FakeModelrunner()
+
+        report = types.SimpleNamespace(run=1, epoch=4)
+        runmgr.load_model(report)
+
+        # load_model's set_config_val("EXP", "run", 1) must be visible to
+        # the nested _select_model call via the ambient context.
+        assert observed_run["run"] == "1"
+        # And it must not have leaked into the unrelated live context.
+        assert context_live.config["EXP"]["run"] == "0"
+
+    def test_load_model_restores_prior_ambient_context_afterwards(self):
+        context_train = self._make_context(run="0")
+        context_live = self._make_context(run="0")
+        set_context(context_live)
+
+        runmgr = Runmanager.__new__(Runmanager)
+        runmgr.context = context_train
+        runmgr.util = Util("runmanager", context=context_train)
+        runmgr.modelrunner = types.SimpleNamespace(
+            _select_model=lambda model_type: types.SimpleNamespace(
+                load=lambda run, epoch: None
+            )
+        )
+
+        runmgr.load_model(types.SimpleNamespace(run=1, epoch=4))
+
+        # Ambient context after the call must be back to whatever it was
+        # before -- load_model must not leave context_train installed globally.
+        assert get_context() is context_live
 
 
 class TestRunmanagerInit:


### PR DESCRIPTION
Fix — decorated Runmanager  with @bind_experiment_context, matching the existing pattern on Experiment. Now every method call on these classes pushes the instance's own context as ambient, so load_model()'s set_config_val("EXP", "run", run) mutation is visible to nested constructions (like a model's Util()) that fall back to get_context() instead of resolving the stale, separately-instantiated live context from predict.py.