### PR TITLE
fixed init model guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 Changelog
 =========
 
+Version 1.8.4 (26-08-16)
+------------------------
+* fix bug: unguarded init_model
+
 Version 1.8.3 (26-08-16)
 ------------------------
-* fux bug: best model reload
+* fix bug: best model reload
 
 Version 1.8.2 (26-08-16)
 ------------------------

--- a/nkululeko/constants.py
+++ b/nkululeko/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.8.3"
+VERSION = "1.8.4"
 SAMPLING_RATE = 16000
 COL_SEX = "gender"
 COL_AGE = "age"

--- a/nkululeko/feat_extract/feats_ast.py
+++ b/nkululeko/feat_extract/feats_ast.py
@@ -105,6 +105,7 @@ class Ast(Featureset):
         return embeddings.ravel()
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_bert.py
+++ b/nkululeko/feat_extract/feats_bert.py
@@ -113,6 +113,7 @@ class Bert(Featureset):
         return y.detach().cpu().numpy()
 
     def extract_sample(self, text):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(text, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_clap.py
+++ b/nkululeko/feat_extract/feats_clap.py
@@ -24,6 +24,7 @@ class ClapSet(Featureset):
         self.model = laion_clap.CLAP_Module(enable_fusion=False)
         self.model.load_ckpt()  # download the default pretrained checkpoint.
         print("loaded clap model")
+        self.model_initialized = True
 
     def extract(self):
         """Extract the features or load them from disk if present."""
@@ -70,6 +71,7 @@ class ClapSet(Featureset):
         return audio_embed[0]
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr)
         return feats

--- a/nkululeko/feat_extract/feats_hubert.py
+++ b/nkululeko/feat_extract/feats_hubert.py
@@ -114,6 +114,7 @@ class Hubert(Featureset):
         return y.flatten()
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_mos.py
+++ b/nkululeko/feat_extract/feats_mos.py
@@ -95,6 +95,7 @@ class MosSet(Featureset):
         return float(mos[0].numpy())
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_snr.py
+++ b/nkululeko/feat_extract/feats_snr.py
@@ -73,6 +73,5 @@ class SnrSet(Featureset):
         return estimated_snr
 
     def extract_sample(self, signal, sr):
-        self.init_model()
         feats = self.get_snr(signal, sr)
         return feats

--- a/nkululeko/feat_extract/feats_spkrec.py
+++ b/nkululeko/feat_extract/feats_spkrec.py
@@ -100,6 +100,7 @@ class Spkrec(Featureset):
         return y.ravel()
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.classifier_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_squim.py
+++ b/nkululeko/feat_extract/feats_squim.py
@@ -101,6 +101,7 @@ class SquimSet(Featureset):
         return pesq, sdr, stoi
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_textclassifier.py
+++ b/nkululeko/feat_extract/feats_textclassifier.py
@@ -112,6 +112,7 @@ class TextClassifier(Featureset):
         return result
 
     def extract_sample(self, text):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_results(text, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_wav2vec2.py
+++ b/nkululeko/feat_extract/feats_wav2vec2.py
@@ -122,6 +122,7 @@ class Wav2vec2(Featureset):
         return y.ravel()
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_wavlm.py
+++ b/nkululeko/feat_extract/feats_wavlm.py
@@ -127,6 +127,7 @@ class Wavlm(Featureset):
         return y.ravel()
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/nkululeko/feat_extract/feats_whisper.py
+++ b/nkululeko/feat_extract/feats_whisper.py
@@ -112,6 +112,7 @@ class Whisper(Featureset):
         return average_embeds
 
     def extract_sample(self, signal, sr):
-        self.init_model()
+        if not self.model_initialized:
+            self.init_model()
         feats = self.get_embeddings(signal, sr, "no file")
         return feats

--- a/tests/feat_extract/test_extract_sample_reinit_guard.py
+++ b/tests/feat_extract/test_extract_sample_reinit_guard.py
@@ -62,10 +62,7 @@ except ImportError:
 def test_extract_sample_only_initializes_model_once(
     cls, flag_attr, call_args, embed_method
 ):
-    with patch(
-        f"{cls.__module__}.Featureset.__init__", return_value=None
-    ):
-        instance = cls.__new__(cls)
+    instance = cls.__new__(cls)
     setattr(instance, flag_attr, False)
     instance.init_model = MagicMock(
         side_effect=lambda: setattr(instance, flag_attr, True)

--- a/tests/feat_extract/test_extract_sample_reinit_guard.py
+++ b/tests/feat_extract/test_extract_sample_reinit_guard.py
@@ -1,0 +1,82 @@
+"""Regression test: extract_sample() must not reload the underlying model
+on every call.
+
+`nkululeko.predict --type model` calls `extract_sample()` once per row.
+Several Featureset subclasses' `extract_sample()` called `init_model()`
+unconditionally (unlike their own `extract()`, which correctly guards with
+`if not self.model_initialized`). For a corpus of thousands of rows, that
+reloads a full HuggingFace/torch/speechbrain model from scratch on every
+single row instead of once -- a severe, silent performance regression with
+no error, just "loading ... model" logged (and the download/load repeated)
+for every prediction.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nkululeko.feat_extract.feats_ast import Ast
+from nkululeko.feat_extract.feats_bert import Bert
+from nkululeko.feat_extract.feats_hubert import Hubert
+from nkululeko.feat_extract.feats_mos import MosSet
+from nkululeko.feat_extract.feats_textclassifier import TextClassifier
+from nkululeko.feat_extract.feats_wav2vec2 import Wav2vec2
+from nkululeko.feat_extract.feats_wavlm import Wavlm
+from nkululeko.feat_extract.feats_whisper import Whisper
+
+# (class, flag attribute name, extract_sample args, embedding method name)
+CASES = [
+    (Wav2vec2, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (Hubert, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (Wavlm, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (Whisper, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (Ast, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (Bert, "model_initialized", ("text",), "get_embeddings"),
+    (TextClassifier, "model_initialized", ("text",), "get_results"),
+    (MosSet, "model_initialized", ("signal", "sr"), "get_embeddings"),
+]
+
+
+try:
+    from nkululeko.feat_extract.feats_clap import ClapSet
+
+    CASES.append((ClapSet, "model_initialized", ("signal", "sr"), "get_embeddings"))
+except ImportError:
+    pass
+
+try:
+    from nkululeko.feat_extract.feats_spkrec import Spkrec
+
+    CASES.append(
+        (Spkrec, "classifier_initialized", ("signal", "sr"), "get_embeddings")
+    )
+except ImportError:
+    pass
+
+
+@pytest.mark.parametrize(
+    "cls, flag_attr, call_args, embed_method",
+    CASES,
+    ids=[c[0].__name__ for c in CASES],
+)
+def test_extract_sample_only_initializes_model_once(
+    cls, flag_attr, call_args, embed_method
+):
+    with patch(
+        f"{cls.__module__}.Featureset.__init__", return_value=None
+    ):
+        instance = cls.__new__(cls)
+    setattr(instance, flag_attr, False)
+    instance.init_model = MagicMock(
+        side_effect=lambda: setattr(instance, flag_attr, True)
+    )
+    setattr(instance, embed_method, MagicMock(return_value="feats"))
+
+    instance.extract_sample(*call_args)
+    instance.extract_sample(*call_args)
+    instance.extract_sample(*call_args)
+
+    assert instance.init_model.call_count == 1, (
+        f"{cls.__name__}.extract_sample() re-initialized the model on a "
+        "repeat call instead of reusing the already-loaded one"
+    )

--- a/tests/feat_extract/test_extract_sample_reinit_guard.py
+++ b/tests/feat_extract/test_extract_sample_reinit_guard.py
@@ -9,9 +9,14 @@ reloads a full HuggingFace/torch/speechbrain model from scratch on every
 single row instead of once -- a severe, silent performance regression with
 no error, just "loading ... model" logged (and the download/load repeated)
 for every prediction.
+
+`feats_snr.py`'s `SnrSet` had a variant of the same copy-paste: it called
+`self.init_model()` even though `SnrSet` (plain SNR estimation, no ML model)
+never defines `init_model` or a `model_initialized` flag at all -- so every
+call to `extract_sample()` raised `AttributeError`, not just a slow reload.
 """
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -19,6 +24,8 @@ from nkululeko.feat_extract.feats_ast import Ast
 from nkululeko.feat_extract.feats_bert import Bert
 from nkululeko.feat_extract.feats_hubert import Hubert
 from nkululeko.feat_extract.feats_mos import MosSet
+from nkululeko.feat_extract.feats_snr import SnrSet
+from nkululeko.feat_extract.feats_squim import SquimSet
 from nkululeko.feat_extract.feats_textclassifier import TextClassifier
 from nkululeko.feat_extract.feats_wav2vec2 import Wav2vec2
 from nkululeko.feat_extract.feats_wavlm import Wavlm
@@ -34,6 +41,7 @@ CASES = [
     (Bert, "model_initialized", ("text",), "get_embeddings"),
     (TextClassifier, "model_initialized", ("text",), "get_results"),
     (MosSet, "model_initialized", ("signal", "sr"), "get_embeddings"),
+    (SquimSet, "model_initialized", ("signal", "sr"), "get_embeddings"),
 ]
 
 
@@ -77,3 +85,15 @@ def test_extract_sample_only_initializes_model_once(
         f"{cls.__name__}.extract_sample() re-initialized the model on a "
         "repeat call instead of reusing the already-loaded one"
     )
+
+
+def test_snrset_extract_sample_does_not_call_init_model():
+    """SnrSet has no model at all -- extract_sample must not reference
+    init_model()/model_initialized, which don't exist on this class."""
+    instance = SnrSet.__new__(SnrSet)
+    instance.get_snr = MagicMock(return_value=12.5)
+
+    result = instance.extract_sample("signal", 16000)
+
+    assert result == 12.5
+    instance.get_snr.assert_called_once_with("signal", 16000)


### PR DESCRIPTION
Confirmed and fixed the reported bug plus 9 more instances of the identical copy-pasted pattern across the feature-extractor modules. extract_sample() — the per-row path nkululeko.predict --type model uses — called init_model() unconditionally instead of guarding it like extract() does, so a full model reload happened on every single row instead of once per corpus