### PR TITLE
add params to result file name only if used

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 1.8.14 (26-08-17)
+-------------------------
+* simplified result names
+
 Version 1.8.13 (26-08-17)
 -------------------------
 * aliased nkululeko with train

--- a/docs/source/config_defaults_reference.md
+++ b/docs/source/config_defaults_reference.md
@@ -21,7 +21,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'FEATS'.'no_reuse'`: `'False'` (nkululeko/feat_extract/feats_cqcc.py:114), `'False'` (nkululeko/feat_extract/feats_emotion2vec.py:78), `'False'` (nkululeko/feat_extract/feats_lfcc.py:124), `False` (nkululeko/feat_extract/feats_mld.py:45), `'False'` (nkululeko/feat_extract/feats_textclassifier.py:57), `False` (nkululeko/feat_extract/featureset.py:48)
 * `'FEATS'.'type'`: `['os']` (nkululeko/bundle.py:220), `'os'` (nkululeko/data/datasplitter.py:410), `['os']` (nkululeko/experiment.py:227), `['os']` (nkululeko/infer.py:208), `None` (nkululeko/predict.py:215), `None` (nkululeko/predict.py:911)
 * `'MODEL'.'C_val'`: `'1.0'` (nkululeko/feat_extract/feats_analyser.py:233), `'1.0'` (nkululeko/feat_extract/feats_analyser.py:304), `'1'` (nkululeko/models/model_svm.py:16), `'0.001'` (nkululeko/models/model_svr.py:16)
-* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:125)
+* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:128)
 * `'MODEL'.'batch_size'`: `32` (nkululeko/models/model_adm.py:190), `8` (nkululeko/models/model_cnn.py:71), `8` (nkululeko/models/model_mlp.py:79), `8` (nkululeko/models/model_mlp_regression.py:79), `'8'` (nkululeko/models/model_tuned.py:59)
 * `'MODEL'.'class_weight'`: `False` (nkululeko/models/model.py:278), `'False'` (nkululeko/models/model.py:302), `False` (nkululeko/models/model.py:317), `'auto'` (nkululeko/models/model_adm.py:93), `'False'` (nkululeko/models/model_svm.py:17), `False` (nkululeko/models/model_tuned.py:438), `False` (nkululeko/models/model_xgb.py:137)
 * `'MODEL'.'device'`: `'cpu'` (nkululeko/autopredict/ap_sid.py:31), `device` (nkululeko/autopredict/ap_text.py:28), `cuda` (nkululeko/feat_extract/feats_agender.py:38), `cuda` (nkululeko/feat_extract/feats_agender_agender.py:36), `cuda` (nkululeko/feat_extract/feats_ast.py:19), `cuda` (nkululeko/feat_extract/feats_auddim.py:34), `cuda` (nkululeko/feat_extract/feats_audmodel.py:45), `cuda` (nkululeko/feat_extract/feats_audwav2vec2.py:38), `cuda` (nkululeko/feat_extract/feats_bert.py:22), `'cpu'` (nkululeko/feat_extract/feats_clap.py:17), `cuda` (nkululeko/feat_extract/feats_emotion2vec.py:31), `cuda` (nkululeko/feat_extract/feats_hubert.py:29), `cuda` (nkululeko/feat_extract/feats_lfcc.py:97), `'cpu'` (nkululeko/feat_extract/feats_mos.py:33), `cuda` (nkululeko/feat_extract/feats_spkrec.py:29), `cuda` (nkululeko/feat_extract/feats_sptk.py:39), `cuda` (nkululeko/feat_extract/feats_squim.py:36), `cuda` (nkululeko/feat_extract/feats_textclassifier.py:24), `cuda` (nkululeko/feat_extract/feats_wav2vec2.py:32), `cuda` (nkululeko/feat_extract/feats_wavlm.py:29), `cuda` (nkululeko/feat_extract/feats_whisper.py:19), `cuda` (nkululeko/models/model_adm.py:62), `cuda` (nkululeko/models/model_adm.py:510), `'cpu'` (nkululeko/models/model_cnn.py:49), `cuda` (nkululeko/models/model_cnn.py:232), `cuda` (nkululeko/models/model_cnn.py:249), `cuda` (nkululeko/models/model_mlp.py:45), `cuda` (nkululeko/models/model_mlp.py:271), `cuda` (nkululeko/models/model_mlp.py:304), `cuda` (nkululeko/models/model_mlp_regression.py:56), `'cpu'` (nkululeko/models/model_mlp_regression.py:261), `'cpu'` (nkululeko/models/model_mlp_regression.py:279), `False` (nkululeko/models/model_tuned.py:44), `'cpu'` (nkululeko/segmenting/seg_pyannote.py:38)
@@ -30,12 +30,12 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'MODEL'.'loss'`: `'cross'` (nkululeko/models/model.py:93), `'bce'` (nkululeko/models/model_adm.py:65), `'mse'` (nkululeko/models/model_mlp_regression.py:35), `'cross'` (nkululeko/models/model_tuned.py:435), `'1-ccc'` (nkululeko/models/model_tuned.py:454)
 * `'MODEL'.'measure'`: `'mse'` (nkululeko/models/model_mlp_regression.py:240), `'ccc'` (nkululeko/models/model_tuned.py:57), `'uar'` (nkululeko/reporting/reporter.py:82), `'mse'` (nkululeko/reporting/reporter.py:93), `'mse'` (nkululeko/reporting/reporter.py:659), `'uar'` (nkululeko/reporting/run_plotter.py:79), `'uar'` (nkululeko/runmanager.py:166), `'uar'` (nkululeko/utils/util.py:649), `'mse'` (nkululeko/utils/util.py:656)
 * `'MODEL'.'scheduler.gamma'`: `'0.5'` (nkululeko/optimizers/scheduler_factory.py:46), `'0.95'` (nkululeko/optimizers/scheduler_factory.py:54)
-* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:143)
+* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:146)
 * `'REPORT'.'latex'`: `False` (nkululeko/experiment.py:90), `'nkululeko_latex'` (nkululeko/reporting/latex_writer.py:39)
 
 | Namespace | Key | Default | Source |
 |---|---|---|---|
-| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:133 |
+| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:136 |
 | 'AUGMENT' | 'augmentations' | `defaults` | nkululeko/augmenting/augmenter_audiomentations.py:31 |
 | 'AUGMENT' | 'bypass_prob' | `0.3` | nkululeko/augmenting/augmenter_auglib.py:60 |
 | 'AUGMENT' | 'crop_dur' | `1.0` | nkululeko/augmenting/augmenter_auglib.py:126 |
@@ -62,7 +62,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'DATA' | 'target' | `'class_label'` / `'emotion'` / `None` | nkululeko/augment.py:81, nkululeko/augmenting/resampler.py:76, nkululeko/bundle.py:56, +14 more |
 | 'DATA' | 'target_divide_by' | `False` | nkululeko/data/datasplitter.py:311 |
 | 'DATA' | 'tests' | `'False'` / `False` | nkululeko/data/dataset.py:725, nkululeko/nkululeko.py:46, nkululeko/testing_predictor.py:59 |
-| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:77 |
+| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:80 |
 | 'DATA' | 'type' | `'dummy'` / `False` | nkululeko/data/dataset.py:817, nkululeko/data/datasplitter.py:236 |
 | 'DATA' | <f'{stratif_var}_bins'> | `False` | nkululeko/data/dataset.py:551 |
 | 'EXP' | 'balancing' | `False` | nkululeko/modelrunner.py:256 |
@@ -167,7 +167,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'KNN_weights' | `'uniform'` | nkululeko/feat_extract/feats_analyser.py:217, nkululeko/feat_extract/feats_analyser.py:266, nkululeko/models/model_knn.py:16, +1 more |
 | 'MODEL' | 'K_val' | `'5'` | nkululeko/feat_extract/feats_analyser.py:218, nkululeko/feat_extract/feats_analyser.py:267, nkululeko/models/model_knn.py:17, +1 more |
 | 'MODEL' | 'activation' | `'relu'` | nkululeko/models/model_mlp.py:89, nkululeko/models/model_mlp_regression.py:89 |
-| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:125 |
+| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:128 |
 | 'MODEL' | 'adm.fusion' | `'weighted'` | nkululeko/models/model_adm.py:134, nkululeko/models/model_adm.py:541 |
 | 'MODEL' | 'adm.hidden_dim' | `'256'` | nkululeko/models/model_adm.py:136, nkululeko/models/model_adm.py:543 |
 | 'MODEL' | 'balancing' | `False` | nkululeko/models/model_tuned.py:74 |
@@ -184,7 +184,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'k_fold_cross' | `False` | nkululeko/experiment.py:71, nkululeko/models/model.py:38 |
 | 'MODEL' | 'kernel' | `'rbf'` | nkululeko/models/model_svm.py:21, nkululeko/models/model_svr.py:18 |
 | 'MODEL' | 'label_smoothing' | `'False'` | nkululeko/models/model.py:48 |
-| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:112 |
+| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:115 |
 | 'MODEL' | 'learning_rate' | `'0.0001'` / `0.3` / `str(default_lr)` | nkululeko/models/model_tuned.py:62, nkululeko/models/model_xgb.py:32, nkululeko/optimizers/optimizer_factory.py:32 |
 | 'MODEL' | 'logo' | `False` | nkululeko/experiment.py:70, nkululeko/models/model.py:37 |
 | 'MODEL' | 'loso' | `False` | nkululeko/experiment.py:69 |
@@ -210,7 +210,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'subsample' | `1.0` | nkululeko/models/model_xgb.py:33 |
 | 'MODEL' | 'threshold' | `'0.5'` | nkululeko/models/model_adm.py:200 |
 | 'MODEL' | 'tuning_params' | `False` | nkululeko/models/model.py:283 |
-| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:143 |
+| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:146 |
 | 'MODEL' | 'validation_split' | `0.2` | nkululeko/models/model_xgb.py:99 |
 | 'MODEL' | 'warmup_epochs' | `'5'` | nkululeko/optimizers/scheduler_factory.py:86 |
 | 'MODEL' | 'weight_decay' | `'0.01'` | nkululeko/optimizers/optimizer_factory.py:36 |
@@ -248,7 +248,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'SEGMENT' | 'result' | `'segmented'` | nkululeko/segment.py:239 |
 | 'SEGMENT' | 'sampling_rate' | `None` | nkululeko/segment.py:69 |
 | <section> | <key> | `str(default)` | nkululeko/utils/util.py:546 |
-| <section> | <name> | `False` | nkululeko/utils/naming.py:62, nkululeko/utils/naming.py:63 |
+| <section> | <name> | `False` | nkululeko/utils/naming.py:65, nkululeko/utils/naming.py:66 |
 | DATA.<d> | 'type' | `'audformat'` | nkululeko/experiment.py:107, nkululeko/experiment.py:170 |
 | DATA.<data_name> | 'check_size' | `False` | nkululeko/file_checker.py:39 |
 | DATA.<data_name> | 'check_vad' | `False` | nkululeko/file_checker.py:69 |

--- a/docs/source/config_defaults_reference.md
+++ b/docs/source/config_defaults_reference.md
@@ -21,7 +21,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'FEATS'.'no_reuse'`: `'False'` (nkululeko/feat_extract/feats_cqcc.py:114), `'False'` (nkululeko/feat_extract/feats_emotion2vec.py:78), `'False'` (nkululeko/feat_extract/feats_lfcc.py:124), `False` (nkululeko/feat_extract/feats_mld.py:45), `'False'` (nkululeko/feat_extract/feats_textclassifier.py:57), `False` (nkululeko/feat_extract/featureset.py:48)
 * `'FEATS'.'type'`: `['os']` (nkululeko/bundle.py:220), `'os'` (nkululeko/data/datasplitter.py:410), `['os']` (nkululeko/experiment.py:227), `['os']` (nkululeko/infer.py:208), `None` (nkululeko/predict.py:215), `None` (nkululeko/predict.py:911)
 * `'MODEL'.'C_val'`: `'1.0'` (nkululeko/feat_extract/feats_analyser.py:233), `'1.0'` (nkululeko/feat_extract/feats_analyser.py:304), `'1'` (nkululeko/models/model_svm.py:16), `'0.001'` (nkululeko/models/model_svr.py:16)
-* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:100)
+* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:125)
 * `'MODEL'.'batch_size'`: `32` (nkululeko/models/model_adm.py:190), `8` (nkululeko/models/model_cnn.py:71), `8` (nkululeko/models/model_mlp.py:79), `8` (nkululeko/models/model_mlp_regression.py:79), `'8'` (nkululeko/models/model_tuned.py:59)
 * `'MODEL'.'class_weight'`: `False` (nkululeko/models/model.py:278), `'False'` (nkululeko/models/model.py:302), `False` (nkululeko/models/model.py:317), `'auto'` (nkululeko/models/model_adm.py:93), `'False'` (nkululeko/models/model_svm.py:17), `False` (nkululeko/models/model_tuned.py:438), `False` (nkululeko/models/model_xgb.py:137)
 * `'MODEL'.'device'`: `'cpu'` (nkululeko/autopredict/ap_sid.py:31), `device` (nkululeko/autopredict/ap_text.py:28), `cuda` (nkululeko/feat_extract/feats_agender.py:38), `cuda` (nkululeko/feat_extract/feats_agender_agender.py:36), `cuda` (nkululeko/feat_extract/feats_ast.py:19), `cuda` (nkululeko/feat_extract/feats_auddim.py:34), `cuda` (nkululeko/feat_extract/feats_audmodel.py:45), `cuda` (nkululeko/feat_extract/feats_audwav2vec2.py:38), `cuda` (nkululeko/feat_extract/feats_bert.py:22), `'cpu'` (nkululeko/feat_extract/feats_clap.py:17), `cuda` (nkululeko/feat_extract/feats_emotion2vec.py:31), `cuda` (nkululeko/feat_extract/feats_hubert.py:29), `cuda` (nkululeko/feat_extract/feats_lfcc.py:97), `'cpu'` (nkululeko/feat_extract/feats_mos.py:33), `cuda` (nkululeko/feat_extract/feats_spkrec.py:29), `cuda` (nkululeko/feat_extract/feats_sptk.py:39), `cuda` (nkululeko/feat_extract/feats_squim.py:36), `cuda` (nkululeko/feat_extract/feats_textclassifier.py:24), `cuda` (nkululeko/feat_extract/feats_wav2vec2.py:32), `cuda` (nkululeko/feat_extract/feats_wavlm.py:29), `cuda` (nkululeko/feat_extract/feats_whisper.py:19), `cuda` (nkululeko/models/model_adm.py:62), `cuda` (nkululeko/models/model_adm.py:510), `'cpu'` (nkululeko/models/model_cnn.py:49), `cuda` (nkululeko/models/model_cnn.py:232), `cuda` (nkululeko/models/model_cnn.py:249), `cuda` (nkululeko/models/model_mlp.py:45), `cuda` (nkululeko/models/model_mlp.py:271), `cuda` (nkululeko/models/model_mlp.py:304), `cuda` (nkululeko/models/model_mlp_regression.py:56), `'cpu'` (nkululeko/models/model_mlp_regression.py:261), `'cpu'` (nkululeko/models/model_mlp_regression.py:279), `False` (nkululeko/models/model_tuned.py:44), `'cpu'` (nkululeko/segmenting/seg_pyannote.py:38)
@@ -30,12 +30,12 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'MODEL'.'loss'`: `'cross'` (nkululeko/models/model.py:93), `'bce'` (nkululeko/models/model_adm.py:65), `'mse'` (nkululeko/models/model_mlp_regression.py:35), `'cross'` (nkululeko/models/model_tuned.py:435), `'1-ccc'` (nkululeko/models/model_tuned.py:454)
 * `'MODEL'.'measure'`: `'mse'` (nkululeko/models/model_mlp_regression.py:240), `'ccc'` (nkululeko/models/model_tuned.py:57), `'uar'` (nkululeko/reporting/reporter.py:82), `'mse'` (nkululeko/reporting/reporter.py:93), `'mse'` (nkululeko/reporting/reporter.py:659), `'uar'` (nkululeko/reporting/run_plotter.py:79), `'uar'` (nkululeko/runmanager.py:166), `'uar'` (nkululeko/utils/util.py:649), `'mse'` (nkululeko/utils/util.py:656)
 * `'MODEL'.'scheduler.gamma'`: `'0.5'` (nkululeko/optimizers/scheduler_factory.py:46), `'0.95'` (nkululeko/optimizers/scheduler_factory.py:54)
-* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:118)
+* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:143)
 * `'REPORT'.'latex'`: `False` (nkululeko/experiment.py:90), `'nkululeko_latex'` (nkululeko/reporting/latex_writer.py:39)
 
 | Namespace | Key | Default | Source |
 |---|---|---|---|
-| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:108 |
+| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:133 |
 | 'AUGMENT' | 'augmentations' | `defaults` | nkululeko/augmenting/augmenter_audiomentations.py:31 |
 | 'AUGMENT' | 'bypass_prob' | `0.3` | nkululeko/augmenting/augmenter_auglib.py:60 |
 | 'AUGMENT' | 'crop_dur' | `1.0` | nkululeko/augmenting/augmenter_auglib.py:126 |
@@ -62,7 +62,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'DATA' | 'target' | `'class_label'` / `'emotion'` / `None` | nkululeko/augment.py:81, nkululeko/augmenting/resampler.py:76, nkululeko/bundle.py:56, +14 more |
 | 'DATA' | 'target_divide_by' | `False` | nkululeko/data/datasplitter.py:311 |
 | 'DATA' | 'tests' | `'False'` / `False` | nkululeko/data/dataset.py:725, nkululeko/nkululeko.py:46, nkululeko/testing_predictor.py:59 |
-| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:52 |
+| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:77 |
 | 'DATA' | 'type' | `'dummy'` / `False` | nkululeko/data/dataset.py:817, nkululeko/data/datasplitter.py:236 |
 | 'DATA' | <f'{stratif_var}_bins'> | `False` | nkululeko/data/dataset.py:551 |
 | 'EXP' | 'balancing' | `False` | nkululeko/modelrunner.py:256 |
@@ -167,7 +167,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'KNN_weights' | `'uniform'` | nkululeko/feat_extract/feats_analyser.py:217, nkululeko/feat_extract/feats_analyser.py:266, nkululeko/models/model_knn.py:16, +1 more |
 | 'MODEL' | 'K_val' | `'5'` | nkululeko/feat_extract/feats_analyser.py:218, nkululeko/feat_extract/feats_analyser.py:267, nkululeko/models/model_knn.py:17, +1 more |
 | 'MODEL' | 'activation' | `'relu'` | nkululeko/models/model_mlp.py:89, nkululeko/models/model_mlp_regression.py:89 |
-| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:100 |
+| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:125 |
 | 'MODEL' | 'adm.fusion' | `'weighted'` | nkululeko/models/model_adm.py:134, nkululeko/models/model_adm.py:541 |
 | 'MODEL' | 'adm.hidden_dim' | `'256'` | nkululeko/models/model_adm.py:136, nkululeko/models/model_adm.py:543 |
 | 'MODEL' | 'balancing' | `False` | nkululeko/models/model_tuned.py:74 |
@@ -184,7 +184,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'k_fold_cross' | `False` | nkululeko/experiment.py:71, nkululeko/models/model.py:38 |
 | 'MODEL' | 'kernel' | `'rbf'` | nkululeko/models/model_svm.py:21, nkululeko/models/model_svr.py:18 |
 | 'MODEL' | 'label_smoothing' | `'False'` | nkululeko/models/model.py:48 |
-| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:87 |
+| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:112 |
 | 'MODEL' | 'learning_rate' | `'0.0001'` / `0.3` / `str(default_lr)` | nkululeko/models/model_tuned.py:62, nkululeko/models/model_xgb.py:32, nkululeko/optimizers/optimizer_factory.py:32 |
 | 'MODEL' | 'logo' | `False` | nkululeko/experiment.py:70, nkululeko/models/model.py:37 |
 | 'MODEL' | 'loso' | `False` | nkululeko/experiment.py:69 |
@@ -210,7 +210,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'subsample' | `1.0` | nkululeko/models/model_xgb.py:33 |
 | 'MODEL' | 'threshold' | `'0.5'` | nkululeko/models/model_adm.py:200 |
 | 'MODEL' | 'tuning_params' | `False` | nkululeko/models/model.py:283 |
-| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:118 |
+| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:143 |
 | 'MODEL' | 'validation_split' | `0.2` | nkululeko/models/model_xgb.py:99 |
 | 'MODEL' | 'warmup_epochs' | `'5'` | nkululeko/optimizers/scheduler_factory.py:86 |
 | 'MODEL' | 'weight_decay' | `'0.01'` | nkululeko/optimizers/optimizer_factory.py:36 |
@@ -248,7 +248,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'SEGMENT' | 'result' | `'segmented'` | nkululeko/segment.py:239 |
 | 'SEGMENT' | 'sampling_rate' | `None` | nkululeko/segment.py:69 |
 | <section> | <key> | `str(default)` | nkululeko/utils/util.py:546 |
-| <section> | <name> | `False` | nkululeko/utils/naming.py:37, nkululeko/utils/naming.py:38 |
+| <section> | <name> | `False` | nkululeko/utils/naming.py:62, nkululeko/utils/naming.py:63 |
 | DATA.<d> | 'type' | `'audformat'` | nkululeko/experiment.py:107, nkululeko/experiment.py:170 |
 | DATA.<data_name> | 'check_size' | `False` | nkululeko/file_checker.py:39 |
 | DATA.<data_name> | 'check_vad' | `False` | nkululeko/file_checker.py:69 |

--- a/docs/source/config_defaults_reference.md
+++ b/docs/source/config_defaults_reference.md
@@ -21,7 +21,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'FEATS'.'no_reuse'`: `'False'` (nkululeko/feat_extract/feats_cqcc.py:114), `'False'` (nkululeko/feat_extract/feats_emotion2vec.py:78), `'False'` (nkululeko/feat_extract/feats_lfcc.py:124), `False` (nkululeko/feat_extract/feats_mld.py:45), `'False'` (nkululeko/feat_extract/feats_textclassifier.py:57), `False` (nkululeko/feat_extract/featureset.py:48)
 * `'FEATS'.'type'`: `['os']` (nkululeko/bundle.py:220), `'os'` (nkululeko/data/datasplitter.py:410), `['os']` (nkululeko/experiment.py:227), `['os']` (nkululeko/infer.py:208), `None` (nkululeko/predict.py:215), `None` (nkululeko/predict.py:911)
 * `'MODEL'.'C_val'`: `'1.0'` (nkululeko/feat_extract/feats_analyser.py:233), `'1.0'` (nkululeko/feat_extract/feats_analyser.py:304), `'1'` (nkululeko/models/model_svm.py:16), `'0.001'` (nkululeko/models/model_svr.py:16)
-* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:128)
+* `'MODEL'.'adm.branches'`: `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:140), `'time,spectral,phase,lfcc,cqcc'` (nkululeko/models/model_adm.py:546), `'time,spectral,phase'` (nkululeko/utils/naming.py:138)
 * `'MODEL'.'batch_size'`: `32` (nkululeko/models/model_adm.py:190), `8` (nkululeko/models/model_cnn.py:71), `8` (nkululeko/models/model_mlp.py:79), `8` (nkululeko/models/model_mlp_regression.py:79), `'8'` (nkululeko/models/model_tuned.py:59)
 * `'MODEL'.'class_weight'`: `False` (nkululeko/models/model.py:278), `'False'` (nkululeko/models/model.py:302), `False` (nkululeko/models/model.py:317), `'auto'` (nkululeko/models/model_adm.py:93), `'False'` (nkululeko/models/model_svm.py:17), `False` (nkululeko/models/model_tuned.py:438), `False` (nkululeko/models/model_xgb.py:137)
 * `'MODEL'.'device'`: `'cpu'` (nkululeko/autopredict/ap_sid.py:31), `device` (nkululeko/autopredict/ap_text.py:28), `cuda` (nkululeko/feat_extract/feats_agender.py:38), `cuda` (nkululeko/feat_extract/feats_agender_agender.py:36), `cuda` (nkululeko/feat_extract/feats_ast.py:19), `cuda` (nkululeko/feat_extract/feats_auddim.py:34), `cuda` (nkululeko/feat_extract/feats_audmodel.py:45), `cuda` (nkululeko/feat_extract/feats_audwav2vec2.py:38), `cuda` (nkululeko/feat_extract/feats_bert.py:22), `'cpu'` (nkululeko/feat_extract/feats_clap.py:17), `cuda` (nkululeko/feat_extract/feats_emotion2vec.py:31), `cuda` (nkululeko/feat_extract/feats_hubert.py:29), `cuda` (nkululeko/feat_extract/feats_lfcc.py:97), `'cpu'` (nkululeko/feat_extract/feats_mos.py:33), `cuda` (nkululeko/feat_extract/feats_spkrec.py:29), `cuda` (nkululeko/feat_extract/feats_sptk.py:39), `cuda` (nkululeko/feat_extract/feats_squim.py:36), `cuda` (nkululeko/feat_extract/feats_textclassifier.py:24), `cuda` (nkululeko/feat_extract/feats_wav2vec2.py:32), `cuda` (nkululeko/feat_extract/feats_wavlm.py:29), `cuda` (nkululeko/feat_extract/feats_whisper.py:19), `cuda` (nkululeko/models/model_adm.py:62), `cuda` (nkululeko/models/model_adm.py:510), `'cpu'` (nkululeko/models/model_cnn.py:49), `cuda` (nkululeko/models/model_cnn.py:232), `cuda` (nkululeko/models/model_cnn.py:249), `cuda` (nkululeko/models/model_mlp.py:45), `cuda` (nkululeko/models/model_mlp.py:271), `cuda` (nkululeko/models/model_mlp.py:304), `cuda` (nkululeko/models/model_mlp_regression.py:56), `'cpu'` (nkululeko/models/model_mlp_regression.py:261), `'cpu'` (nkululeko/models/model_mlp_regression.py:279), `False` (nkululeko/models/model_tuned.py:44), `'cpu'` (nkululeko/segmenting/seg_pyannote.py:38)
@@ -30,12 +30,12 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 * `'MODEL'.'loss'`: `'cross'` (nkululeko/models/model.py:93), `'bce'` (nkululeko/models/model_adm.py:65), `'mse'` (nkululeko/models/model_mlp_regression.py:35), `'cross'` (nkululeko/models/model_tuned.py:435), `'1-ccc'` (nkululeko/models/model_tuned.py:454)
 * `'MODEL'.'measure'`: `'mse'` (nkululeko/models/model_mlp_regression.py:240), `'ccc'` (nkululeko/models/model_tuned.py:57), `'uar'` (nkululeko/reporting/reporter.py:82), `'mse'` (nkululeko/reporting/reporter.py:93), `'mse'` (nkululeko/reporting/reporter.py:659), `'uar'` (nkululeko/reporting/run_plotter.py:79), `'uar'` (nkululeko/runmanager.py:166), `'uar'` (nkululeko/utils/util.py:649), `'mse'` (nkululeko/utils/util.py:656)
 * `'MODEL'.'scheduler.gamma'`: `'0.5'` (nkululeko/optimizers/scheduler_factory.py:46), `'0.95'` (nkululeko/optimizers/scheduler_factory.py:54)
-* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:146)
+* `'MODEL'.'type'`: `'svm'` (nkululeko/bundle.py:224), `''` (nkululeko/utils/naming.py:156)
 * `'REPORT'.'latex'`: `False` (nkululeko/experiment.py:90), `'nkululeko_latex'` (nkululeko/reporting/latex_writer.py:39)
 
 | Namespace | Key | Default | Source |
 |---|---|---|---|
-| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:136 |
+| 'AUGMENT' | 'augment' | `False` | nkululeko/aug_train.py:40, nkululeko/augment.py:57, nkululeko/utils/naming.py:146 |
 | 'AUGMENT' | 'augmentations' | `defaults` | nkululeko/augmenting/augmenter_audiomentations.py:31 |
 | 'AUGMENT' | 'bypass_prob' | `0.3` | nkululeko/augmenting/augmenter_auglib.py:60 |
 | 'AUGMENT' | 'crop_dur' | `1.0` | nkululeko/augmenting/augmenter_auglib.py:126 |
@@ -62,7 +62,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'DATA' | 'target' | `'class_label'` / `'emotion'` / `None` | nkululeko/augment.py:81, nkululeko/augmenting/resampler.py:76, nkululeko/bundle.py:56, +14 more |
 | 'DATA' | 'target_divide_by' | `False` | nkululeko/data/datasplitter.py:311 |
 | 'DATA' | 'tests' | `'False'` / `False` | nkululeko/data/dataset.py:725, nkululeko/nkululeko.py:46, nkululeko/testing_predictor.py:59 |
-| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:80 |
+| 'DATA' | 'trains' | `False` | nkululeko/utils/naming.py:90 |
 | 'DATA' | 'type' | `'dummy'` / `False` | nkululeko/data/dataset.py:817, nkululeko/data/datasplitter.py:236 |
 | 'DATA' | <f'{stratif_var}_bins'> | `False` | nkululeko/data/dataset.py:551 |
 | 'EXP' | 'balancing' | `False` | nkululeko/modelrunner.py:256 |
@@ -167,7 +167,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'KNN_weights' | `'uniform'` | nkululeko/feat_extract/feats_analyser.py:217, nkululeko/feat_extract/feats_analyser.py:266, nkululeko/models/model_knn.py:16, +1 more |
 | 'MODEL' | 'K_val' | `'5'` | nkululeko/feat_extract/feats_analyser.py:218, nkululeko/feat_extract/feats_analyser.py:267, nkululeko/models/model_knn.py:17, +1 more |
 | 'MODEL' | 'activation' | `'relu'` | nkululeko/models/model_mlp.py:89, nkululeko/models/model_mlp_regression.py:89 |
-| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:128 |
+| 'MODEL' | 'adm.branches' | `'time,spectral,phase'` / `'time,spectral,phase,lfcc,cqcc'` | nkululeko/models/model_adm.py:140, nkululeko/models/model_adm.py:546, nkululeko/utils/naming.py:138 |
 | 'MODEL' | 'adm.fusion' | `'weighted'` | nkululeko/models/model_adm.py:134, nkululeko/models/model_adm.py:541 |
 | 'MODEL' | 'adm.hidden_dim' | `'256'` | nkululeko/models/model_adm.py:136, nkululeko/models/model_adm.py:543 |
 | 'MODEL' | 'balancing' | `False` | nkululeko/models/model_tuned.py:74 |
@@ -184,7 +184,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'k_fold_cross' | `False` | nkululeko/experiment.py:71, nkululeko/models/model.py:38 |
 | 'MODEL' | 'kernel' | `'rbf'` | nkululeko/models/model_svm.py:21, nkululeko/models/model_svr.py:18 |
 | 'MODEL' | 'label_smoothing' | `'False'` | nkululeko/models/model.py:48 |
-| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:115 |
+| 'MODEL' | 'layers' | `False` | nkululeko/utils/naming.py:125 |
 | 'MODEL' | 'learning_rate' | `'0.0001'` / `0.3` / `str(default_lr)` | nkululeko/models/model_tuned.py:62, nkululeko/models/model_xgb.py:32, nkululeko/optimizers/optimizer_factory.py:32 |
 | 'MODEL' | 'logo' | `False` | nkululeko/experiment.py:70, nkululeko/models/model.py:37 |
 | 'MODEL' | 'loso' | `False` | nkululeko/experiment.py:69 |
@@ -210,7 +210,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'MODEL' | 'subsample' | `1.0` | nkululeko/models/model_xgb.py:33 |
 | 'MODEL' | 'threshold' | `'0.5'` | nkululeko/models/model_adm.py:200 |
 | 'MODEL' | 'tuning_params' | `False` | nkululeko/models/model.py:283 |
-| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:146 |
+| 'MODEL' | 'type' | `''` / `'svm'` | nkululeko/bundle.py:224, nkululeko/utils/naming.py:156 |
 | 'MODEL' | 'validation_split' | `0.2` | nkululeko/models/model_xgb.py:99 |
 | 'MODEL' | 'warmup_epochs' | `'5'` | nkululeko/optimizers/scheduler_factory.py:86 |
 | 'MODEL' | 'weight_decay' | `'0.01'` | nkululeko/optimizers/optimizer_factory.py:36 |
@@ -248,7 +248,7 @@ This is a contributor-facing cross-check, not user documentation - see [ini_file
 | 'SEGMENT' | 'result' | `'segmented'` | nkululeko/segment.py:239 |
 | 'SEGMENT' | 'sampling_rate' | `None` | nkululeko/segment.py:69 |
 | <section> | <key> | `str(default)` | nkululeko/utils/util.py:546 |
-| <section> | <name> | `False` | nkululeko/utils/naming.py:65, nkululeko/utils/naming.py:66 |
+| <section> | <name> | `False` | nkululeko/utils/naming.py:75, nkululeko/utils/naming.py:76 |
 | DATA.<d> | 'type' | `'audformat'` | nkululeko/experiment.py:107, nkululeko/experiment.py:170 |
 | DATA.<data_name> | 'check_size' | `False` | nkululeko/file_checker.py:39 |
 | DATA.<data_name> | 'check_vad' | `False` | nkululeko/file_checker.py:69 |

--- a/nkululeko/constants.py
+++ b/nkululeko/constants.py
@@ -1,4 +1,4 @@
-VERSION = "1.8.13"
+VERSION = "1.8.14"
 SAMPLING_RATE = 16000
 COL_SEX = "gender"
 COL_AGE = "age"

--- a/nkululeko/utils/naming.py
+++ b/nkululeko/utils/naming.py
@@ -2,6 +2,31 @@
 import ast
 import os
 
+# MODEL.type values backed by an artificial neural network (see
+# Model.is_ann() and the model_type "ann"/"finetuned" tags set by these
+# models' __init__). These are the only ones reading MODEL.optimizer,
+# MODEL.drop, MODEL.activation and MODEL.loss (learning_rate is shared
+# with xgb below, which reads it too but as a boosting hyperparameter).
+ANN_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg", "adm", "finetune"})
+# MODEL.type values backed by a kernel SVM — only these read
+# MODEL.C_val / MODEL.kernel.
+SVM_MODEL_TYPES = frozenset({"svm", "svr"})
+
+# Maps a MODEL.<key> naming option to the MODEL.type values it's actually
+# read by, so result filenames only mention parameters the chosen model
+# type uses. Keys absent from this map (e.g. MODEL.class_weight,
+# MODEL.logo, MODEL.k_fold_cross, all FEATS.* options) apply regardless of
+# model type and are always included when set.
+MODEL_OPTION_TYPES = {
+    "C_val": SVM_MODEL_TYPES,
+    "kernel": SVM_MODEL_TYPES,
+    "drop": ANN_MODEL_TYPES,
+    "activation": ANN_MODEL_TYPES,
+    "loss": ANN_MODEL_TYPES,
+    "optimizer": ANN_MODEL_TYPES,
+    "learning_rate": ANN_MODEL_TYPES | {"xgb"},
+}
+
 
 class NamingMixin:
     """Mixin providing experiment and model naming methods for Util."""
@@ -129,14 +154,18 @@ class NamingMixin:
             ["MODEL", "loss"],
             ["MODEL", "logo"],
             ["MODEL", "learning_rate"],
+            ["MODEL", "optimizer"],
             ["MODEL", "k_fold_cross"],
             ["FEATS", "balancing"],
             ["FEATS", "scale"],
             ["FEATS", "set"],
             ["FEATS", "wav2vec2.layer"],
         ]
-        for option in options:
-            return_string += self._get_value_descript(option[0], option[1]).replace(
+        for section, name in options:
+            applicable_types = MODEL_OPTION_TYPES.get(name)
+            if applicable_types is not None and mt not in applicable_types:
+                continue
+            return_string += self._get_value_descript(section, name).replace(
                 ".", "-"
             )
             return_string = return_string.replace("__", "_").strip("_")

--- a/nkululeko/utils/naming.py
+++ b/nkululeko/utils/naming.py
@@ -4,9 +4,9 @@ import os
 
 # MODEL.type values backed by an artificial neural network (see
 # Model.is_ann() and the model_type "ann"/"finetuned" tags set by these
-# models' __init__). These are the only ones reading MODEL.optimizer,
-# MODEL.drop, MODEL.activation and MODEL.loss (learning_rate is shared
-# with xgb below, which reads it too but as a boosting hyperparameter).
+# models' __init__). All five read MODEL.loss (mlp/cnn via the shared
+# Model._setup_criterion(), mlp_reg/adm/finetune each directly); the other
+# ANN-only options below are read by narrower subsets of this group.
 ANN_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg", "adm", "finetune"})
 # MODEL.type values backed by a kernel SVM — only these read
 # MODEL.C_val / MODEL.kernel.
@@ -14,6 +14,16 @@ SVM_MODEL_TYPES = frozenset({"svm", "svr"})
 # MODEL.type values with a configurable layer stack — only these read
 # MODEL.layers (adm and finetune have a fixed architecture instead).
 LAYERED_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg"})
+# ANN types that build their optimizer via optimizer_factory.get_optimizer()
+# and thus read MODEL.optimizer. TunedModel (finetune) configures its own
+# optimizer elsewhere and never reads it.
+OPTIMIZER_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg", "adm"})
+# ANN types that read MODEL.drop for dropout. model_adm.py has no dropout
+# config of its own.
+DROPOUT_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg", "finetune"})
+# ANN types with a configurable hidden-layer activation function. cnn, adm
+# and finetune don't expose MODEL.activation.
+ACTIVATION_MODEL_TYPES = frozenset({"mlp", "mlp_reg"})
 
 # Maps a MODEL.<key> naming option to the MODEL.type values it's actually
 # read by, so result filenames only mention parameters the chosen model
@@ -23,10 +33,10 @@ LAYERED_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg"})
 MODEL_OPTION_TYPES = {
     "C_val": SVM_MODEL_TYPES,
     "kernel": SVM_MODEL_TYPES,
-    "drop": ANN_MODEL_TYPES,
-    "activation": ANN_MODEL_TYPES,
+    "drop": DROPOUT_MODEL_TYPES,
+    "activation": ACTIVATION_MODEL_TYPES,
     "loss": ANN_MODEL_TYPES,
-    "optimizer": ANN_MODEL_TYPES,
+    "optimizer": OPTIMIZER_MODEL_TYPES,
     "learning_rate": ANN_MODEL_TYPES | {"xgb"},
 }
 

--- a/nkululeko/utils/naming.py
+++ b/nkululeko/utils/naming.py
@@ -11,6 +11,9 @@ ANN_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg", "adm", "finetune"})
 # MODEL.type values backed by a kernel SVM — only these read
 # MODEL.C_val / MODEL.kernel.
 SVM_MODEL_TYPES = frozenset({"svm", "svr"})
+# MODEL.type values with a configurable layer stack — only these read
+# MODEL.layers (adm and finetune have a fixed architecture instead).
+LAYERED_MODEL_TYPES = frozenset({"cnn", "mlp", "mlp_reg"})
 
 # Maps a MODEL.<key> naming option to the MODEL.type values it's actually
 # read by, so result filenames only mention parameters the chosen model
@@ -142,7 +145,7 @@ class NamingMixin:
     def get_model_description(self):
         mt = self.config_val("MODEL", "type", "")
         ft = self._get_feat_type_string()
-        layers = self._get_layer_string()
+        layers = self._get_layer_string() if mt in LAYERED_MODEL_TYPES else ""
         return_string = f"{mt}_{ft}{layers}"
 
         options = [

--- a/tests/utils/test_naming.py
+++ b/tests/utils/test_naming.py
@@ -560,6 +560,150 @@ type = os
         self.assertNotIn("activation", desc)
         self.assertNotIn("loss", desc)
 
+    def test_model_description_includes_activation_for_mlp_and_mlp_reg(self):
+        for model_type in ("mlp", "mlp_reg"):
+            c = configparser.ConfigParser()
+            c.read_string(f"""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = {model_type}
+activation = tanh
+[FEATS]
+type = os
+""")
+            glob_conf.config = c
+            u = Util("test")
+            self.assertIn(
+                "activation-tanh", u.get_model_description(), msg=model_type
+            )
+
+    def test_model_description_excludes_activation_for_cnn_adm_finetune(self):
+        for model_type in ("cnn", "adm", "finetune"):
+            c = configparser.ConfigParser()
+            c.read_string(f"""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = {model_type}
+activation = tanh
+[FEATS]
+type = os
+""")
+            glob_conf.config = c
+            u = Util("test")
+            self.assertNotIn(
+                "activation", u.get_model_description(), msg=model_type
+            )
+
+    def test_model_description_includes_optimizer_for_cnn_mlp_mlp_reg_adm(self):
+        for model_type in ("cnn", "mlp", "mlp_reg", "adm"):
+            c = configparser.ConfigParser()
+            c.read_string(f"""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = {model_type}
+optimizer = adamw
+[FEATS]
+type = os
+""")
+            glob_conf.config = c
+            u = Util("test")
+            self.assertIn(
+                "optimizer-adamw", u.get_model_description(), msg=model_type
+            )
+
+    def test_model_description_excludes_optimizer_for_finetune(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = finetune
+optimizer = adamw
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertNotIn("optimizer", u.get_model_description())
+
+    def test_model_description_includes_drop_for_cnn_mlp_mlp_reg_finetune(self):
+        for model_type in ("cnn", "mlp", "mlp_reg", "finetune"):
+            c = configparser.ConfigParser()
+            c.read_string(f"""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = {model_type}
+drop = 0.3
+[FEATS]
+type = os
+""")
+            glob_conf.config = c
+            u = Util("test")
+            self.assertIn("drop-0", u.get_model_description(), msg=model_type)
+
+    def test_model_description_excludes_drop_for_adm(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = adm
+drop = 0.3
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertNotIn("drop", u.get_model_description())
+
+    def test_model_description_includes_loss_for_all_ann_types(self):
+        for model_type in ("cnn", "mlp", "mlp_reg", "adm", "finetune"):
+            c = configparser.ConfigParser()
+            c.read_string(f"""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = {model_type}
+loss = cross
+[FEATS]
+type = os
+""")
+            glob_conf.config = c
+            u = Util("test")
+            self.assertIn("loss-cross", u.get_model_description(), msg=model_type)
+
     def test_aug_suffix_invalid_syntax(self):
         c = configparser.ConfigParser()
         c.read_string("""

--- a/tests/utils/test_naming.py
+++ b/tests/utils/test_naming.py
@@ -374,6 +374,150 @@ type = os
         u = Util("test")
         self.assertEqual(u._get_adm_branch_suffix(), "")
 
+    def test_model_description_includes_optimizer_for_ann(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = mlp
+optimizer = adamw
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertIn("optimizer-adamw", u.get_model_description())
+
+    def test_model_description_excludes_optimizer_for_non_ann(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = svm
+optimizer = adamw
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertNotIn("optimizer", u.get_model_description())
+
+    def test_model_description_includes_learning_rate_for_xgb(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = xgb
+learning_rate = 0.3
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertIn("learning_rate-0", u.get_model_description())
+
+    def test_model_description_excludes_learning_rate_for_svm(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = svm
+learning_rate = 0.3
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        self.assertNotIn("learning_rate", u.get_model_description())
+
+    def test_model_description_includes_c_val_kernel_for_svm(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = svm
+C_val = 1.0
+kernel = linear
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        desc = u.get_model_description()
+        self.assertIn("C_val-1", desc)
+        self.assertIn("kernel-linear", desc)
+
+    def test_model_description_excludes_c_val_kernel_for_xgb(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = xgb
+C_val = 1.0
+kernel = linear
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        desc = u.get_model_description()
+        self.assertNotIn("C_val", desc)
+        self.assertNotIn("kernel", desc)
+
+    def test_model_description_excludes_drop_activation_loss_for_svm(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = svm
+drop = 0.5
+activation = relu
+loss = cross
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        desc = u.get_model_description()
+        self.assertNotIn("drop", desc)
+        self.assertNotIn("activation", desc)
+        self.assertNotIn("loss", desc)
+
     def test_aug_suffix_invalid_syntax(self):
         c = configparser.ConfigParser()
         c.read_string("""

--- a/tests/utils/test_naming.py
+++ b/tests/utils/test_naming.py
@@ -494,6 +494,48 @@ type = os
         self.assertNotIn("C_val", desc)
         self.assertNotIn("kernel", desc)
 
+    def test_model_description_includes_layers_for_mlp(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = mlp
+layers = [64, 128]
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        desc = u.get_model_description()
+        self.assertIn("64", desc)
+        self.assertIn("128", desc)
+
+    def test_model_description_excludes_layers_for_xgb(self):
+        c = configparser.ConfigParser()
+        c.read_string("""
+[EXP]
+name = test
+root = /tmp
+[DATA]
+databases = ["emodb"]
+target = emotion
+[MODEL]
+type = xgb
+layers = [64, 128]
+[FEATS]
+type = os
+""")
+        glob_conf.config = c
+        u = Util("test")
+        desc = u.get_model_description()
+        self.assertNotIn("64", desc)
+        self.assertNotIn("128", desc)
+
     def test_model_description_excludes_drop_activation_loss_for_svm(self):
         c = configparser.ConfigParser()
         c.read_string("""


### PR DESCRIPTION
before, many parameter names were added to the result file names, irrespective if they are being used or not, e.g. also an MLP result might have "c_val-10" in the name, just because it's in the config.